### PR TITLE
[Bugfix] Fix batch size in slapo-deepspeed

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,9 +35,9 @@ pip3 install -e ".[dev]"
 
 - This repo:
 ```
-git clone https://github.com/chhzh123/model-schedule
-cd model-schedule
-export PYTHONPATH=`pwd`:$PYTHONPATH
+git clone https://github.com/awslabs/slapo.git slapo
+cd slapo
+pip3 install -e ".[dev]"
 ```
 
 You can run these examples using Megatron-LM framework (referring to `../benchmark/bench_single_node.py`).


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The default micro-batch size at the beginning of the function leads to incorrect arguments passed into the DeepSpeed engine. This PR removes the default micro-batch size.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

