### PR TITLE
[Pipeline] Tie weight analysis

### DIFF
--- a/ci/task_lint.sh
+++ b/ci/task_lint.sh
@@ -11,13 +11,13 @@ python3 scripts/lint/check_license_header.py HEAD~1
 python3 scripts/lint/check_license_header.py origin/main
 
 echo "Check Python formats using black..."
-#python3 -m pip install black==22.10.0
-#python3 -m pip install transformers==4.25.1 --no-deps
+python3 -m pip install black==22.10.0
+python3 -m pip install transformers==4.25.1 --no-deps
 bash ./scripts/lint/git-black.sh HEAD~1
 bash ./scripts/lint/git-black.sh origin/main
 
 echo "Running pylint on slapo"
-#python3 -m pip install pylint==2.14.0 astroid==2.11.6
+python3 -m pip install pylint==2.14.0 astroid==2.11.6
 python3 -m pylint slapo --rcfile=./scripts/lint/pylintrc
 
 echo "Running pylint on tests"

--- a/ci/task_lint.sh
+++ b/ci/task_lint.sh
@@ -11,13 +11,13 @@ python3 scripts/lint/check_license_header.py HEAD~1
 python3 scripts/lint/check_license_header.py origin/main
 
 echo "Check Python formats using black..."
-python3 -m pip install black==22.10.0
-python3 -m pip install transformers==4.25.1 --no-deps
+#python3 -m pip install black==22.10.0
+#python3 -m pip install transformers==4.25.1 --no-deps
 bash ./scripts/lint/git-black.sh HEAD~1
 bash ./scripts/lint/git-black.sh origin/main
 
 echo "Running pylint on slapo"
-python3 -m pip install pylint==2.14.0 astroid==2.11.6
+#python3 -m pip install pylint==2.14.0 astroid==2.11.6
 python3 -m pylint slapo --rcfile=./scripts/lint/pylintrc
 
 echo "Running pylint on tests"

--- a/slapo/initialization.py
+++ b/slapo/initialization.py
@@ -59,7 +59,7 @@ def init_on_device(device: torch.device, include_buffers: bool = False):
 
     def register_empty_parameter(module, name, param):
         old_register_parameter(module, name, param)
-        if param is not None:
+        if param is not None and param.device != device:
             param_cls = type(module._parameters[name])
             kwargs = module._parameters[name].__dict__
             module._parameters[name] = param_cls(

--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -295,6 +295,7 @@ class DeepSpeedPipeStageWrapper(nn.Module):
         ret = tuple(ret)
         return ret
 
+
 @register_model_dialect("deepspeed", "pipeline_engine")
 def deepspeed_pipe_engine(
     stage_modules,

--- a/slapo/model_dialect/registry.py
+++ b/slapo/model_dialect/registry.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Framework model dialect registration."""
 
-DIALECTS = {"pipeline": {}, "log_parser": {}}
+DIALECTS = {"pipeline_stage": {}, "pipeline_engine": {}, "log_parser": {}}
 
 
 def register_model_dialect(target, cls_type):

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -301,6 +301,10 @@ def analyze_tie_weights(top_mod):
     def _traverse_children(stage_id, prefix, curr_mod_name, curr_mod):
         full_prefix = f"{prefix}.{curr_mod_name}" if prefix else curr_mod_name
 
+        # We cannot use named_parameters(recurse=True) but have to explicitly
+        # traverse submodules recursively. This is because tie weights will
+        # only show up once in named_parameters. In other words, we cannot
+        # identify tie weights with named_parameters(recurse=True).
         for curr_param_name, curr_param in curr_mod.named_parameters():
             curr_param_full_name = f"{full_prefix}.{curr_param_name}"
             curr_param_id = id(curr_param)

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -4,8 +4,8 @@
 import operator
 from collections import OrderedDict
 
+import torch
 from torch import fx
-
 from torch.fx.passes.split_module import split_module
 
 from .logger import get_logger
@@ -160,7 +160,7 @@ def propagate_partition(sch, starting_stage_id=0, stop_at=None):
                         ph2arg[value.name if isinstance(value, fx.Node) else None],
                     )
                 )
-            elif ( # pylint: disable=comparison-with-callable
+            elif (  # pylint: disable=comparison-with-callable
                 user.op == "call_function" and user.target == operator.getitem
             ):
                 users_to_replace.append((user, ph2arg[ret_dict[user.args[1]].name]))
@@ -264,7 +264,8 @@ def analyze_pipeline_module(top_mod):
             "when tracing, and they are not removed by the PyTorch tracer. "
             "This should not be an issue if the None arguments are really 'None' "
             "in the training process.",
-            liveness[0], liveness[-1],
+            liveness[0],
+            liveness[-1],
         )
     else:
         liveness[0] = liveness[-1]
@@ -272,6 +273,78 @@ def analyze_pipeline_module(top_mod):
 
     stage_id_2_name = {v: k for k, v in submod_2_stage_id.items()}
     return stage_id_2_arg_names, stage_id_2_name, liveness
+
+
+def analyze_tie_weights(top_mod):
+    """Analyze if there is any tie weights (two weights in different module
+    share the same memory) partitioned into different pipeline stages.
+
+    Parameters
+    ----------
+    top_mod : torch.nn.Module
+        The top-level module. This should be a top pipeline module, so
+        1) it should already be traced and partitioned, and
+        2) it should have a number of submodules that matches pipeline stages.
+
+    Returns
+    -------
+    tie_groups : Dict[str, Set[Tuple[str, int]]]
+    """
+    # Mapping from parameter name to (the pipeline stage ID, the parameter object ID).
+    params = {}
+    # Mapping from the primary key (i.e., the first parameter name)
+    # of a tie group to the tie group.
+    tie_groups = {}
+    # Mapping from paramter name to the primary key of the tie group.
+    param_name_2_group_key = {}
+
+    def _traverse_children(stage_id, prefix, curr_mod_name, curr_mod):
+        full_prefix = f"{prefix}.{curr_mod_name}" if prefix else curr_mod_name
+
+        for curr_param_name, curr_param in curr_mod.named_parameters():
+            curr_param_full_name = f"{full_prefix}.{curr_param_name}"
+            curr_param_id = id(curr_param)
+            if curr_param_full_name in params:
+                continue
+
+            # Check if this parameter is tie to another one in a different stage.
+            for target_param_full_name, (
+                target_stage,
+                target_param_id,
+            ) in params.items():
+                if stage_id != target_stage and curr_param_id == target_param_id:
+                    if target_param_full_name in param_name_2_group_key:
+                        # Get the tie group of the target parameter.
+                        tie_group_key = param_name_2_group_key[target_param_full_name]
+                        tie_group = tie_groups[tie_group_key]
+                    else:
+                        # Create a new tie group, and use the target parameter name
+                        # as the primary key.
+                        param_name_2_group_key[
+                            target_param_full_name
+                        ] = target_param_full_name
+                        tie_group = set([(target_param_full_name, target_stage)])
+                        tie_groups[target_param_full_name] = tie_group
+
+                    # Add the current parameter to the tie group.
+                    param_name_2_group_key[
+                        curr_param_full_name
+                    ] = target_param_full_name
+                    tie_group.add((curr_param_full_name, stage_id))
+
+            # Add this parameter for the rest analysis.
+            params[curr_param_full_name] = (stage_id, id(curr_param))
+
+        # Traverse children.
+        for name, mod in curr_mod.named_children():
+            _traverse_children(stage_id, f"{full_prefix}", name, mod)
+
+    for stage_id, (mod_name, stage_mod) in enumerate(top_mod.named_children()):
+        _traverse_children(stage_id, "", mod_name, stage_mod)
+
+    # Explicitly delete the reference to parameters for safety.
+    del params
+    return list(tie_groups.values())
 
 
 def generate_pipeline_partition(sch):
@@ -308,7 +381,10 @@ def generate_pipeline_partition(sch):
     return sch
 
 
-def generate_pipeline_modules(sch, target):
+def generate_pipeline_modules(
+    sch, target, topology=None, param_dtype=torch.float16, **kwargs
+):
+    # Analyze pipelien module for liveness and arguments.
     partitioned_mod = sch.mod
     (
         stage_id_2_arg_names,
@@ -317,7 +393,7 @@ def generate_pipeline_modules(sch, target):
     ) = analyze_pipeline_module(partitioned_mod)
 
     # Get the pipeline wrapper class.
-    pipe_wrapper_cls = get_dialect_cls("pipeline", target)
+    pipe_wrapper_cls = get_dialect_cls("pipeline_stage", target)
 
     # Generate wrappers for pipelined modules
     res_partition = []
@@ -333,4 +409,11 @@ def generate_pipeline_modules(sch, target):
                 stage_id_2_arg_names,
             )
         )
-    return res_partition
+
+    pipe_engine_fn = get_dialect_cls("pipeline_engine", target)
+    return pipe_engine_fn(
+        res_partition,
+        topology,
+        param_dtype,
+        **kwargs,
+    )

--- a/tests/test_pipeline_partition.py
+++ b/tests/test_pipeline_partition.py
@@ -43,6 +43,7 @@ def test_analyze_tie_weights():
         model.stage2.linear.weight = model.stage0.wte.weight
 
     tie_weights = slapo.pipeline.analyze_tie_weights(model)
+
     assert len(tie_weights) == 1
     assert len(tie_weights[0]) == 3
     assert ("stage0.wte.weight", 0) in tie_weights[0]

--- a/tests/test_pipeline_partition.py
+++ b/tests/test_pipeline_partition.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test pipeline partition related logic."""
+import pytest
+
+from torch import nn
+import slapo
+
+
+def test_analyze_tie_weights():
+    class Stage0(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.wte = nn.Embedding(10, 10)
+            self.linear = nn.Linear(10, 10, bias=False)
+
+        def forward(self, x):
+            return self.linear(self.wte(x))
+
+    class StageN(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(10, 10, bias=False)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.stage0 = Stage0()
+            self.stage1 = StageN()
+            self.stage2 = StageN()
+
+        def forward(self, x):
+            return self.stage2(self.stage1(self.stage0(x)))
+
+    with slapo.init_empty_weights():
+        model = Model()
+        # Tie weights
+        model.stage1.linear.weight = model.stage0.wte.weight
+        model.stage2.linear.weight = model.stage0.wte.weight
+
+    tie_weights = slapo.pipeline.analyze_tie_weights(model)
+    assert len(tie_weights) == 1
+    assert len(tie_weights[0]) == 3
+    assert ("stage0.wte.weight", 0) in tie_weights[0]
+    assert ("stage1.linear.weight", 1) in tie_weights[0]
+    assert ("stage2.linear.weight", 2) in tie_weights[0]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR analyzes whether parameters are tie together by looking at their `nn.Paramter` object IDs. Accordingly, this analysis has to be done before the consolidation (if needed); otherwise all `nn.Parameter` objects will be replaced so that their object IDs won't be the same anymore.

Note that the above analysis works only when parameters are pointing to the same Python object. In other words, for the distributed training that requires weight consolidation, users have to explicitly call `tie_weights` one more time when initializing the model with empty weights. For example:

```python
with slapo.init_empty_weights():
    model = get_model()
    model.tie_weights()

sch = slapo.create_schedule(model, ...)
# The .build does the following in order:
# 1. Partition pipeline stages.
# 2. Tie weight analysis.
# 3. Consolidation (this wipes out the previous tie weights in the model)
# 4. Liveness analysis.
# 5. Pipeline module construction (this makes use the tie weight and liveness analysis results)
sch.build(...)
```

In addition, this PR also refactors the pipeline logic in `schedu.build`. The ultimate goal is to ensure that `schedule.build` doesn't have any framework specific logic (e.g., `if target == "deepspeed":`).

cc @szhengac @zarzen 

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

