### PR TITLE
[Pipeline] Register tie weights

### DIFF
--- a/.github/workflows/ci_unit_test.yml
+++ b/.github/workflows/ci_unit_test.yml
@@ -112,7 +112,7 @@ jobs:
             --source-ref ${{ needs.check_status.outputs.ref }} \
             --repo ${{ needs.check_status.outputs.repo }} \
             --wait \
-            --command "bash ./ci/task_unit_test.sh"
+            --command "bash ./ci/install_test_pkgs.sh; bash ./ci/task_unit_test.sh"
   update_ci_badge:
     needs: [unit_test]
     # Run this job whatever the unit tests were success or not.

--- a/ci/install_test_pkgs.sh
+++ b/ci/install_test_pkgs.sh
@@ -4,4 +4,4 @@
 
 python3 -m pip install black==22.10.0
 python3 -m pip install transformers==4.25.1 --no-deps
-python3 -m pip install pylint==2.14.0 astroid==2.11.6
+python3 -m pip install pylint==2.14.0 astroid==2.11.6 mock==4.0.3

--- a/ci/submit_job.py
+++ b/ci/submit_job.py
@@ -327,8 +327,8 @@ def main():
         response = aws_batch.describe_jobs(jobs=[job_id])
         status = response["jobs"][0]["status"]
         if status in {"SUCCEEDED", "FAILED"}:
-            if status == "SUCCEEDED" and log_stream_name is None:
-                # If the job is succeeded within a print period so that
+            if log_stream_name is None:
+                # If the job is ended within a print period so that
                 # we have not got the log stream name, we need to get it here.
                 log_stream_name = response["jobs"][0]["container"]["logStreamName"]
             if log_stream_name:

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -8,6 +8,10 @@ set -o pipefail
 
 nvidia-smi -L
 
+python3 -m pip install black==22.10.0
+python3 -m pip install transformers==4.25.1 --no-deps
+python3 -m pip install pylint==2.14.0 astroid==2.11.6 mock==4.0.3
+
 echo "Running unit tests..."
 # -r: redirect the output of local rank 1 to None so that
 # only local rank 0's output is printed to the console.

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -8,10 +8,6 @@ set -o pipefail
 
 nvidia-smi -L
 
-python3 -m pip install black==22.10.0
-python3 -m pip install transformers==4.25.1 --no-deps
-python3 -m pip install pylint==2.14.0 astroid==2.11.6 mock==4.0.3
-
 echo "Running unit tests..."
 # -r: redirect the output of local rank 1 to None so that
 # only local rank 0's output is printed to the console.

--- a/conftest.py
+++ b/conftest.py
@@ -22,10 +22,12 @@ def init_dist(request):
     try:
         dist.init_process_group(backend="nccl")
     except Exception as err:
-        print(f"Skip === {str(err)}")
-        pytest.skip(f"Skip {__file__} because torch.distributed is not initialized")
+        print(f"Skip initializing dist group: {str(err)}")
 
     def destory_dist():
-        dist.destroy_process_group()
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
 
     request.addfinalizer(destory_dist)

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -23,7 +23,7 @@ shift 1
 PASSWORD="$1"
 shift 1
 
-LOCAL_IMAGE_NAME=slapo:latest
+LOCAL_IMAGE_NAME=slapo-ci:latest
 REMOTE_IMAGE_NAME_VER=${DOCKER_HUB_ACCOUNT}/slapo:ci-${VERSION}
 REMOTE_IMAGE_NAME_LST=${DOCKER_HUB_ACCOUNT}/slapo:ci-latest
 

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -64,8 +64,8 @@ def schedule_model(
     # Shard other parameters if MP group > 1.
     if sch.world_size > 1:
         replace_and_shard_mlp(sch[prefix], config, delay_init=delay_init)
-        tie_sch = sch["lm_head"] if "lm_head" in sch else None
-        shard_word_embedding(sch[prefix], tie_sch, config.vocab_size)
+        head_sch = sch["lm_head"] if "lm_head" in sch else None
+        shard_word_embedding(sch[prefix], head_sch, config.vocab_size)
 
         # Broadcast input to all devices within the MP group.
         # This is not required when running on Megatron.

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -64,7 +64,8 @@ def schedule_model(
     # Shard other parameters if MP group > 1.
     if sch.world_size > 1:
         replace_and_shard_mlp(sch[prefix], config, delay_init=delay_init)
-        shard_word_embedding(sch[prefix], config.vocab_size)
+        tie_sch = sch["lm_head"] if "lm_head" in sch else None
+        shard_word_embedding(sch[prefix], tie_sch, config.vocab_size)
 
         # Broadcast input to all devices within the MP group.
         # This is not required when running on Megatron.

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -203,7 +203,7 @@ def remove_cast(sch, config, attn_path="h.N.attn.attention"):
     return cnt
 
 
-def shard_word_embedding(sch, tie_sch, vocab_size, word_embed_name="wte"):
+def shard_word_embedding(sch, head_sch, vocab_size, word_embed_name="wte"):
     if sch.world_size == 1:
         return
 
@@ -232,10 +232,8 @@ def shard_word_embedding(sch, tie_sch, vocab_size, word_embed_name="wte"):
 
     sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn=fwd_post_hook)
 
-    # Since word embedding is tied to the output embedding, we have to
-    # shard it as well if presents.
-    if tie_sch:
-        tie_sch.shard("weight", axis=0)
+    # Shard output embedding.
+    head_sch.shard("weight", axis=0)
 
 
 def shard_qkv(

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -203,7 +203,7 @@ def remove_cast(sch, config, attn_path="h.N.attn.attention"):
     return cnt
 
 
-def shard_word_embedding(sch, vocab_size, word_embed_name="wte"):
+def shard_word_embedding(sch, tie_sch, vocab_size, word_embed_name="wte"):
     if sch.world_size == 1:
         return
 
@@ -231,6 +231,11 @@ def shard_word_embedding(sch, vocab_size, word_embed_name="wte"):
         return output
 
     sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn=fwd_post_hook)
+
+    # Since word embedding is tied to the output embedding, we have to
+    # shard it as well if presents.
+    if tie_sch:
+        tie_sch.shard("weight", axis=0)
 
 
 def shard_qkv(

--- a/examples/opt/model.py
+++ b/examples/opt/model.py
@@ -65,8 +65,8 @@ def schedule_model(
     # Shard other parameters if MP group > 1.
     if sch.world_size > 1:
         replace_and_shard_mlp(sch[prefix], config, delay_init=delay_init)
-        tie_sch = sch["lm_head"] if "lm_head" in sch else None
-        shard_word_embedding(sch[prefix], tie_sch, config.vocab_size)
+        head_sch = sch["lm_head"] if "lm_head" in sch else None
+        shard_word_embedding(sch[prefix], head_sch, config.vocab_size)
 
         # Broadcast input to all devices within the MP group.
         # This is not required when running on Megatron.

--- a/examples/opt/model.py
+++ b/examples/opt/model.py
@@ -65,7 +65,8 @@ def schedule_model(
     # Shard other parameters if MP group > 1.
     if sch.world_size > 1:
         replace_and_shard_mlp(sch[prefix], config, delay_init=delay_init)
-        shard_word_embedding(sch[prefix], config.vocab_size)
+        tie_sch = sch["lm_head"] if "lm_head" in sch else None
+        shard_word_embedding(sch[prefix], tie_sch, config.vocab_size)
 
         # Broadcast input to all devices within the MP group.
         # This is not required when running on Megatron.

--- a/examples/opt/schedule.py
+++ b/examples/opt/schedule.py
@@ -231,7 +231,7 @@ def remove_cast(sch, config, attn_path="h.N.attn.attention"):
 
 
 def shard_word_embedding(
-    sch, tie_sch, vocab_size, word_embed_name="decoder.embed_tokens"
+    sch, head_sch, vocab_size, word_embed_name="decoder.embed_tokens"
 ):
     if sch.world_size == 1:
         return
@@ -261,10 +261,8 @@ def shard_word_embedding(
 
     sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn=fwd_post_hook)
 
-    # Since word embedding is tied to the output embedding, we have to
-    # shard it as well if presents.
-    if tie_sch:
-        tie_sch.shard("weight", axis=0)
+    # Shard output embedding.
+    head_sch.shard("weight", axis=0)
 
 
 def shard_qkv(

--- a/slapo/model_dialect/__init__.py
+++ b/slapo/model_dialect/__init__.py
@@ -5,4 +5,5 @@
 from .megatron.utils import MegatronLogParser
 from .deepspeed.utils import DeepSpeedLogParser
 from .deepspeed.pipeline import DeepSpeedPipeStageWrapper
+from .deepspeed.engine import init_ds_engine
 from .registry import get_all_dialects, get_dialect_cls

--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from ..registry import register_model_dialect
+from ...logger import get_logger, INFO
+
+# Change INFO to DEBUG for more verbose logging.
+logger = get_logger("DS-Engine", INFO)
+
+
+@register_model_dialect("deepspeed", "runtime_engine")
+def init_ds_engine(model, **kwargs):
+    """Initialize the DeepSpeed engine."""
+    import deepspeed
+
+    if "config" not in kwargs:
+        raise ValueError("DeepSpeed config not provided.")
+
+    # pylint: disable=unbalanced-tuple-unpacking
+    model, optimizer, _, _ = deepspeed.initialize(
+        model=model,
+        config=kwargs["config"],
+        model_parameters=[p for p in model.parameters() if p.requires_grad],
+    )
+    return model, optimizer

--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from ..registry import register_model_dialect
 from ...logger import get_logger, INFO
 
-# Change INFO to DEBUG for more verbose logging.
 logger = get_logger("DS-Engine", INFO)
 
 

--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -429,9 +429,7 @@ def deepspeed_pipe_engine(
         for full_name, stage_id in tie_weight:
             if stage_id == my_stage_id:
                 if found:
-                    raise RuntimeError(
-                        f"Cannot tie two weights in the same stage"
-                    )
+                    raise RuntimeError(f"Cannot tie two weights in the same stage")
                 assert isinstance(stage_modules[stage_id], DeepSpeedPipeStageWrapper)
                 module = stage_modules[stage_id].mod
                 for token in full_name.split(".")[:-1]:

--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -375,8 +375,10 @@ def deepspeed_pipe_engine(
             break
         except ValueError:
             pass
-    else:
-        raise RuntimeError(f"Cannot identify the stage ID of global rank {global_rank}")
+
+    # If this device is not in any stage, no need to tie weights.
+    if my_stage_id == -1:
+        return model
 
     for tie_weight_set in tie_weight_groups:
         logger.info(

--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -324,7 +324,7 @@ class DeepSpeedPipeStageWrapper(nn.Module):
 
 @register_model_dialect("deepspeed", "pipeline_engine")
 def deepspeed_pipe_engine(
-    sch,
+    sch_metadata,
     stage_modules,
     **kwargs,
 ):
@@ -370,7 +370,7 @@ def deepspeed_pipe_engine(
         param_dtype=param_dtype,
     )
 
-    tie_weights = list(sch.metadata.tie_weights.values())
+    tie_weights = list(sch_metadata.tie_weights.values())
     if not tie_weights:
         return model
 

--- a/slapo/model_dialect/registry.py
+++ b/slapo/model_dialect/registry.py
@@ -39,8 +39,8 @@ def get_dialect_cls(cls_type, target, allow_none=False):
         raise ValueError(f"Only support {DIALECTS.keys()}, but got {cls_type}")
     if target not in DIALECTS[cls_type]:
         if allow_none:
-            if "default" in DIALECTS[cls_type]:
-                target = "default"
+            if None in DIALECTS[cls_type]:
+                target = None
             else:
                 raise ValueError(
                     f"Target {target} does not register default dialect for {cls_type}"

--- a/slapo/model_dialect/registry.py
+++ b/slapo/model_dialect/registry.py
@@ -40,7 +40,7 @@ def get_dialect_cls(cls_type, target, allow_none=False):
     if target not in DIALECTS[cls_type]:
         if allow_none:
             if "default" in DIALECTS[cls_type]:
-                return DIALECTS[cls_type]["default"]
+                target = "default"
             else:
                 raise ValueError(
                     f"Target {target} does not register default dialect for {cls_type}"

--- a/slapo/model_dialect/registry.py
+++ b/slapo/model_dialect/registry.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Framework model dialect registration."""
 
-DIALECTS = {"pipeline_stage": {}, "pipeline_engine": {}, "log_parser": {}}
+DIALECTS = {
+    "pipeline_stage": {},
+    "pipeline_engine": {},
+    "runtime_engine": {None: lambda model, **kwargs: (model, None)},
+    "log_parser": {},
+}
 
 
 def register_model_dialect(target, cls_type):
@@ -28,12 +33,20 @@ def get_all_dialects(cls_type):
     return DIALECTS[cls_type]
 
 
-def get_dialect_cls(cls_type, target):
+def get_dialect_cls(cls_type, target, allow_none=False):
     """Get the framework model dialect class."""
     if cls_type not in DIALECTS:
         raise ValueError(f"Only support {DIALECTS.keys()}, but got {cls_type}")
     if target not in DIALECTS[cls_type]:
-        raise ValueError(
-            f"Target {target} not registered for {cls_type} model dialects"
-        )
+        if allow_none:
+            if "default" in DIALECTS[cls_type]:
+                return DIALECTS[cls_type]["default"]
+            else:
+                raise ValueError(
+                    f"Target {target} does not register default dialect for {cls_type}"
+                )
+        else:
+            raise ValueError(
+                f"Target {target} not registered for {cls_type} model dialects"
+            )
     return DIALECTS[cls_type][target]

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -4,7 +4,6 @@
 import operator
 from collections import OrderedDict
 
-import torch
 from torch import fx
 from torch.fx.passes.split_module import split_module
 

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -275,7 +275,7 @@ def analyze_pipeline_module(top_mod):
     return stage_id_2_arg_names, stage_id_2_name, liveness
 
 
-def analyze_tie_weights(top_mod):
+def analyze_tie_weights(top_mod, is_pipeline_partitioned):
     """Analyze if there is any tie weights (two weights in different module
     share the same memory) partitioned into different pipeline stages.
 
@@ -286,17 +286,22 @@ def analyze_tie_weights(top_mod):
         1) it should already be traced and partitioned, and
         2) it should have a number of submodules that matches pipeline stages.
 
+    is_pipeline_partitioned : bool
+        Whether the module is partitioned for pipeline or not. If not,
+        then all tie weights will have stage ID 0.
+
     Returns
     -------
-    tie_groups : Dict[str, Set[Tuple[str, int]]]
+    tie_groups : Dict[int, Set[Tuple[str, int]]]
+        Mapping from the nn.Parameter object to the set of parameter names
+        that are tied to it. The set of parameter names is a tuple of
+        (parameter name, stage ID). The stage ID is 0 if the module is not
+        partitioned for pipeline.
     """
-    # Mapping from parameter name to (the pipeline stage ID, the parameter object ID).
+    # Mapping from parameter name to (the pipeline stage ID, the parameter object).
     params = {}
-    # Mapping from the primary key (i.e., the first parameter name)
-    # of a tie group to the tie group.
+    # The result tie groups.
     tie_groups = {}
-    # Mapping from paramter name to the primary key of the tie group.
-    param_name_2_group_key = {}
 
     def _traverse_children(stage_id, prefix, curr_mod_name, curr_mod):
         full_prefix = f"{prefix}.{curr_mod_name}" if prefix else curr_mod_name
@@ -306,69 +311,58 @@ def analyze_tie_weights(top_mod):
         # only show up once in named_parameters. In other words, we cannot
         # identify tie weights with named_parameters(recurse=True).
         for curr_param_name, curr_param in curr_mod.named_parameters():
-            curr_param_full_name = f"{full_prefix}.{curr_param_name}"
-            curr_param_id = id(curr_param)
+            curr_param_full_name = (
+                f"{full_prefix}.{curr_param_name}" if full_prefix else curr_param_name
+            )
             if curr_param_full_name in params:
                 continue
 
             # Check if this parameter is tie to another one in a different stage.
             for target_param_full_name, (
                 target_stage,
-                target_param_id,
+                target_param,
             ) in params.items():
-                if stage_id != target_stage and curr_param_id == target_param_id:
-                    if target_param_full_name in param_name_2_group_key:
+                if is_pipeline_partitioned and stage_id == target_stage:
+                    continue
+                if id(curr_param) == id(target_param):
+                    if curr_param in tie_groups:
                         # Get the tie group of the target parameter.
-                        tie_group_key = param_name_2_group_key[target_param_full_name]
-                        tie_group = tie_groups[tie_group_key]
+                        tie_group = tie_groups[curr_param]
                     else:
                         # Create a new tie group, and use the target parameter name
                         # as the primary key.
-                        param_name_2_group_key[
-                            target_param_full_name
-                        ] = target_param_full_name
                         tie_group = set([(target_param_full_name, target_stage)])
-                        tie_groups[target_param_full_name] = tie_group
+                        tie_groups[curr_param] = tie_group
 
                     # Add the current parameter to the tie group.
-                    param_name_2_group_key[
-                        curr_param_full_name
-                    ] = target_param_full_name
                     tie_group.add((curr_param_full_name, stage_id))
 
             # Add this parameter for the rest analysis.
-            params[curr_param_full_name] = (stage_id, id(curr_param))
+            params[curr_param_full_name] = (stage_id, curr_param)
 
         # Traverse children.
         for name, mod in curr_mod.named_children():
             _traverse_children(stage_id, f"{full_prefix}", name, mod)
 
-    for stage_id, (mod_name, stage_mod) in enumerate(top_mod.named_children()):
-        _traverse_children(stage_id, "", mod_name, stage_mod)
+    if is_pipeline_partitioned:
+        for stage_id, (mod_name, stage_mod) in enumerate(top_mod.named_children()):
+            _traverse_children(stage_id, "", mod_name, stage_mod)
+    else:
+        _traverse_children(0, "", "", top_mod)
 
     # Explicitly delete the reference to parameters for safety.
     del params
-    return list(tie_groups.values())
 
+    # Remove module name.
+    if is_pipeline_partitioned:
+        ret = {}
+        for param, tie_group_set in tie_groups.items():
+            group = [(name[name.find(".") + 1 :], sid) for name, sid in tie_group_set]
+            ret[param] = group
+    else:
+        ret = tie_groups
 
-def analyze_tie_ranks(tie_weight_groups, topology):
-    tie_ranks = []
-    for tie_weight_set in tie_weight_groups:
-        tie_stage_ranks = []
-        for _, stage_id in tie_weight_set:
-            stage_ranks = topology.filter_match(pipe=stage_id)
-            tie_stage_ranks.append(stage_ranks)
-
-        num_ranks_same_stage = len(tie_stage_ranks[0])
-        num_stages = len(tie_stage_ranks)
-        group_ranks = []
-        for i in range(num_ranks_same_stage):
-            sub_group_ranks = []
-            for j in range(num_stages):
-                sub_group_ranks.append(tie_stage_ranks[j][i])
-            group_ranks.append(sorted(sub_group_ranks))
-        tie_ranks.append(group_ranks)
-    return tie_ranks
+    return ret
 
 
 def generate_pipeline_partition(sch):
@@ -405,9 +399,7 @@ def generate_pipeline_partition(sch):
     return sch
 
 
-def generate_pipeline_modules(
-    sch, target, topology=None, param_dtype=torch.float16, **kwargs
-):
+def build_pipeline_model(sch, target, **kwargs):
     # Analyze pipelien module for liveness and arguments.
     partitioned_mod = sch.mod
     (
@@ -436,8 +428,7 @@ def generate_pipeline_modules(
 
     pipe_engine_fn = get_dialect_cls("pipeline_engine", target)
     return pipe_engine_fn(
+        sch,
         res_partition,
-        topology,
-        param_dtype,
         **kwargs,
     )

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -427,7 +427,7 @@ def build_pipeline_model(sch, target, **kwargs):
 
     pipe_engine_fn = get_dialect_cls("pipeline_engine", target)
     return pipe_engine_fn(
-        sch,
+        sch.metadata,
         res_partition,
         **kwargs,
     )

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -252,7 +252,7 @@ class Schedule:
             else:
                 new_param = nn.Parameter(new_tensor)
             self.mod.register_parameter(tensor_name, new_param)
-        except AttributeError as err:
+        except AttributeError:
             buffer = self.mod.get_buffer(tensor_name)
             new_buffer, sharded_size = _shard(tensor_name, buffer)
             self.mod.register_buffer(tensor_name, new_buffer)

--- a/tests/test_pipeline_partition.py
+++ b/tests/test_pipeline_partition.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Test pipeline partition related logic."""
+# pylint: disable=duplicate-code
 import pytest
 from mock import MagicMock
 
@@ -65,7 +66,7 @@ def test_analyze_tie_weights():
     assert ("linear.weight", 2) in val
 
 
-def test_analyze_tie_ranks():
+def test_deepspeed_analyze_tie_ranks():
     # Mock deepspeed.runtime.pipe.topology.PipeModelDataParallelTopology
     # This mocked topology assumes pp=4, tp=2, dp=1.
     topology = MagicMock()


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

When running pipeline on DeepSpeed MiCS (not open source yet), we need to call `model.register_tied_weights` to let the runtime sync tied weights. Accordingly, this PR leverages tie weight analysis and tie rank analysis to call the API.

Meanwhile, since we analyze tied weights by checking whether two or more weights are referring to the same nn.Parameter Python object, any operations that replace the nn.Parameter object will break this assumption. For example, `shard` and `replace`. While we leave `replace` as the future work, this PR deals with sharding as follows:

1. When `create_schedule`, we analyze tied weights and generate a dict `self.tie_weights = {param: param}`, where key and value are the same nn.Parameter.
2. When `shard` the parameter in `self.tie_weights`, we update the corresponding value with the new nn.Parameter (i.e., `{param: new_param}`).
3. When `shard` another parameter in the same tie group, we directly use the same `new_param` to keep they tied.
4. When `build`, we analyze the tied weights again. This should result in the same tie weight groups as step 1.

The biggest limitation/concern of this approach is that we require users to shard all tie weights. If users forget to shard one of them, the one without sharding won't be tied anymore. In the future we should have a checker to remind users.

Other changes in this PR:
1. [Test] Fix a bug that test fixture skipped all tests when torchrun is not used.
5. [Model] Sharding tied weights for GPT and OPT. T5 TBA.
6. [Build] Move all framework related logic to dialects.
7. [TieRankAnalysis] Also return the corresponding pipeline stage IDs in addition to tie ranks.
8. [Test] Add unit tests.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac @zarzen 