### PR TITLE
[Pipeline] Drop last batch in DeepSpeed scripts

### DIFF
--- a/examples/data_util.py
+++ b/examples/data_util.py
@@ -68,6 +68,7 @@ def get_dataloader(model_name, micro_batch_size, enable_pipeline, cache_dir=None
         batch_size=micro_batch_size,
         sampler=DistributedSampler(train_dataset),
         collate_fn=get_data_move_and_group_fn(enable_pipeline),
+        drop_last=True,
     )
 
     val_loader = DataLoader(
@@ -75,6 +76,7 @@ def get_dataloader(model_name, micro_batch_size, enable_pipeline, cache_dir=None
         batch_size=micro_batch_size,
         sampler=DistributedSampler(val_dataset),
         collate_fn=get_data_move_and_group_fn(enable_pipeline),
+        drop_last=True,
     )
     return train_loader, val_loader
 

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -1059,7 +1059,6 @@ def build(
         sch.metadata.tie_weights = analyze_tie_weights(
             sch.mod, is_pipeline_partitioned=True
         )
-        print(f"tie_weight_groups: {sch.metadata.tie_weights}")
 
     # delay initialization
     if init_weights:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The DeepSpeed pipeline runtime doesn't support dynamic batch, meaning that the last batch may cause hanging. This PR drops the last batch to workaround this issue.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac @zarzen 