### PR TITLE
[Bugfix] Fix sequence parallelism

### DIFF
--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -117,6 +117,7 @@ def train(args):
             group=group,
             pipeline_cuts=pipeline_cuts,
             delay_init=enable_pipeline,
+            sequence_parallel=args.sequence_parallel,
         )
 
     if enable_pipeline:
@@ -237,15 +238,20 @@ if __name__ == "__main__":
         " it uses default value associated with the model name",
     )
     parser.add_argument(
-        "--nlayers", type=int, default=-1, help="number of transformer layers"
+        "--nlayers", type=int, default=-1, help="Number of transformer layers"
     )
     parser.add_argument(
-        "--num-attn-heads", type=int, default=-1, help="number of attention heads"
+        "--num-attn-heads", type=int, default=-1, help="Number of attention heads"
     )
     parser.add_argument(
-        "--pmp", type=int, default=2, help="pipeline model parallel size"
+        "--pmp", type=int, default=2, help="Pipeline model parallel size"
     )
-    parser.add_argument("--tmp", type=int, default=8, help="tensor parallel size")
+    parser.add_argument("--tmp", type=int, default=8, help="Tensor parallel size")
+    parser.add_argument(
+        "--sequence_parallel",
+        action="store_true",
+        help="Sequence parallelism is enabled",
+    )
     args = parser.parse_args()
 
     if args.hidden_size > 0:

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -53,7 +53,7 @@ def schedule_model(
         config,
         delay_init=delay_init,
         disable_flash_attn=disable_flash_attn,
-        sequence_parallel=sequence_parallel
+        sequence_parallel=sequence_parallel,
     )
     logger.info(f"Replace {cnt} attention patterns", ranks=0)
 

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -82,7 +82,7 @@ def replace_and_shard_attention(
     attn_path="h.N.attn.attention",
     delay_init=True,
     disable_flash_attn=False,
-    sequence_parallel=False
+    sequence_parallel=False,
 ):
     from epoi.inject.policy.gpt import InjectHFGPTAttentionPolicy
     from epoi.ops.xformers_attn import GenericSelfAttention

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -82,6 +82,7 @@ def replace_and_shard_attention(
     attn_path="h.N.attn.attention",
     delay_init=True,
     disable_flash_attn=False,
+    sequence_parallel=False
 ):
     from epoi.inject.policy.gpt import InjectHFGPTAttentionPolicy
     from epoi.ops.xformers_attn import GenericSelfAttention
@@ -174,16 +175,24 @@ def replace_and_shard_attention(
         if sch.world_size > 1:
             sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)
             sub_sch["module.FusedQKV_0.fused_linear"].shard("bias", axis=0)
-            sub_sch["module.FusedQKV_0.fused_linear"].sync(
-                mode="bwd_post", sync_op_or_fn="all_reduce"
-            )
             sub_sch["module.out_proj"].shard("weight", axis=1)
-            sub_sch["module.out_proj"].sync(
-                mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
-            )
-            sub_sch["module.resid_dropout"].sync(
-                mode="fwd_post", sync_op_or_fn="all_gather", axis=1
-            )
+
+            if sequence_parallel:
+                sub_sch["module.FusedQKV_0.fused_linear"].sync(
+                    mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
+                )
+
+                sub_sch["module.out_proj"].sync(
+                    mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
+                )
+            else:
+                sub_sch["module.FusedQKV_0.fused_linear"].sync(
+                    mode="bwd_post", sync_op_or_fn="all_reduce"
+                )
+                sub_sch["module.out_proj"].sync(
+                    mode="fwd_post", sync_op_or_fn="all_reduce"
+                )
+
         cnt += 1
 
     return cnt
@@ -209,7 +218,15 @@ def remove_cast(sch, config, attn_path="h.N.attn.attention"):
     return cnt
 
 
-def shard_word_embedding(sch, head_sch, vocab_size, word_embed_name="wte"):
+def shard_word_embedding(
+    sch,
+    head_sch,
+    vocab_size,
+    word_embed_name="wte",
+    pos_embed_name="wpe",
+    final_ln_name="ln_f",
+    sequence_parallel=False,
+):
     if sch.world_size == 1:
         return
 
@@ -238,6 +255,16 @@ def shard_word_embedding(sch, head_sch, vocab_size, word_embed_name="wte"):
 
     sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn=fwd_post_hook)
 
+    if sequence_parallel:
+        sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn="scatter", axis=1)
+        sch[pos_embed_name].sync(mode="fwd_post", sync_op_or_fn="scatter", axis=1)
+        sch[final_ln_name].sync(
+            mode="fwd_post",
+            sync_op_or_fn="all_gather",
+            axis=1,
+            tensor_parallel_output_grad=False,
+        )
+
     # Shard output embedding.
     if head_sch is not None:
         head_sch.shard("weight", axis=0)
@@ -249,6 +276,7 @@ def shard_qkv(
     attn_path="h.N.attn.attention",
     qkv_name="FusedQKV_0",
     out_proj_name="out_proj",
+    sequence_parallel=False,
 ):
     """Untested."""
     num_layers = config.num_layers
@@ -277,19 +305,34 @@ def shard_qkv(
         prefix = attn_path.replace("N", str(idx))
         sch[f"{prefix}.{qkv_name}.fused_linear"].shard("weight", axis=0)
         sch[f"{prefix}.{qkv_name}.fused_linear"].shard("bias", axis=0)
-        sch[f"{prefix}.{qkv_name}.fused_linear"].sync(
-            mode="bwd_post", sync_op_or_fn="all_reduce"
-        )
 
         sch[f"{prefix}.{out_proj_name}"].shard("weight", axis=1)
-        sch[f"{prefix}.{out_proj_name}"].sync(
-            mode="fwd_post", sync_op_or_fn="all_reduce"
-        )
+
+        if sequence_parallel:
+            sch[f"{prefix}.{qkv_name}.fused_linear"].sync(
+                mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
+            )
+            sch[f"{prefix}.{out_proj_name}"].sync(
+                mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
+            )
+        else:
+            sch[f"{prefix}.{qkv_name}.fused_linear"].sync(
+                mode="bwd_post", sync_op_or_fn="all_reduce"
+            )
+            sch[f"{prefix}.{out_proj_name}"].sync(
+                mode="fwd_post", sync_op_or_fn="all_reduce"
+            )
+
         fix_shape_after_shard(prefix)
 
 
 def replace_and_shard_mlp(
-    sch, config, path="h.N.mlp", fc_names=["c_fc", "c_proj"], delay_init=True
+    sch,
+    config,
+    path="h.N.mlp",
+    fc_names=["c_fc", "c_proj"],
+    delay_init=True,
+    sequence_parallel=False,
 ):
     from epoi.inject.policy.gpt import InjectHFGPTMLPPolicy
 
@@ -305,19 +348,44 @@ def replace_and_shard_mlp(
             if sch.world_size > 1:
                 sub_sch["fc_in"].shard("weight", axis=0)
                 sub_sch["act"].shard("bias", axis=0)
-                sub_sch["fc_in"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
                 sub_sch["fc_out"].shard("weight", axis=1)
-                sub_sch["fc_out"].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
+
+                if sequence_parallel:
+                    sub_sch["fc_in"].sync(
+                        mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
+                    )
+                    sub_sch["fc_out"].sync(
+                        mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
+                    )
+                else:
+                    sub_sch["fc_in"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
+                    sub_sch["fc_out"].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
+
         elif sch.world_size > 1:
+            sch[f"{prefix}.{fc_names[0]}"].sync(
+                mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
+            )
             sch[f"{prefix}.{fc_names[0]}"].shard("weight", axis=0)
             sch[f"{prefix}.{fc_names[0]}"].shard("bias", axis=0)
-            sch[f"{prefix}.{fc_names[0]}"].sync(
-                mode="bwd_post", sync_op_or_fn="all_reduce"
-            )
             sch[f"{prefix}.{fc_names[1]}"].shard("weight", axis=1)
             sch[f"{prefix}.{fc_names[1]}"].sync(
-                mode="fwd_post", sync_op_or_fn="all_reduce"
+                mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
             )
+
+            if sequence_parallel:
+                sch[f"{prefix}.{fc_names[0]}"].sync(
+                    mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
+                )
+                sch[f"{prefix}.{fc_names[1]}"].sync(
+                    mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
+                )
+            else:
+                sch[f"{prefix}.{fc_names[0]}"].sync(
+                    mode="bwd_post", sync_op_or_fn="all_reduce"
+                )
+                sch[f"{prefix}.{fc_names[1]}"].sync(
+                    mode="fwd_post", sync_op_or_fn="all_reduce"
+                )
 
 
 def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0):

--- a/examples/opt/schedule.py
+++ b/examples/opt/schedule.py
@@ -205,12 +205,7 @@ def replace_and_shard_attention(
                 mode="bwd_post", sync_op_or_fn="all_reduce"
             )
             sub_sch["module.out_proj"].shard("weight", axis=1)
-            sub_sch["module.out_proj"].sync(
-                mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
-            )
-            sub_sch["module.resid_dropout"].sync(
-                mode="fwd_post", sync_op_or_fn="all_gather", axis=1
-            )
+            sub_sch["module.out_proj"].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
         cnt += 1
 
     return cnt

--- a/examples/wideresnet/schedule.py
+++ b/examples/wideresnet/schedule.py
@@ -91,7 +91,12 @@ def shard_layers(sch, config):
             # Forward: partitioned output (followed by allgather).
             # Backward: allreduce.
             sub_sch["conv3"].shard("weight", axis=0)
-            sub_sch["conv3"].sync(mode="fwd_post", sync_op_or_fn="all_gather")
+            sub_sch["conv3"].sync(
+                mode="fwd_post",
+                sync_op_or_fn="all_gather",
+                axis=1,
+                tensor_parallel_output_grad=False,
+            )
             sub_sch["conv3"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
 
 

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -378,7 +378,7 @@ class Schedule:
             if mode == "fwd_post" and sync_op_or_fn == "scatter":
                 if "output_type" in self.metadata.shard:
                     raise ValueError(
-                        "Output of {self.path} cannot be scatter along axis {axis}, if the layer is sharded"
+                        "Output of {self.path} cannot be scatter along axis {axis}, if its parameter is sharded"
                     )
 
             if "output_type" not in self.metadata.shard:
@@ -401,7 +401,7 @@ class Schedule:
             elif mode == "fwd_pre" and sync_op_or_fn == "all_gather":
                 if output_type == "partial":
                     raise ValueError(
-                        "Cannot all-gather a partition input when the layer weight is partitioned in the input dimension"
+                        "Cannot all-gather a partition input since the operator with parameter sharded in the input dimension expects partitioned input"
                     )
             elif sync_op_or_fn == "all_reduce":
                 if mode == "fwd_post" and output_type == "partition":

--- a/slapo/sharding/__init__.py
+++ b/slapo/sharding/__init__.py
@@ -3,4 +3,8 @@
 """Sharding utilities."""
 
 from .infer_type import *
-from .utils import all_gather_forward_output, reduce_scatter_forward_output
+from .utils import (
+    all_gather_forward_output,
+    reduce_scatter_forward_output,
+    scatter_forward_output,
+)

--- a/slapo/sharding/utils.py
+++ b/slapo/sharding/utils.py
@@ -204,10 +204,10 @@ def all_gather_forward_output(inp, dim, group, tensor_parallel_output_grad=True)
         The dimension to all-gather along.
     group: torch.distributed.ProcessGroup
         The process group to all-gather.
-    tensor_parallel_output_grad: If the operator following the gather operation is
-        sharded, output gradients need to be reduce
-        scattered and whereas if the operator is duplicated,
-        output gradients only need to be scattered.
+    tensor_parallel_output_grad: bool
+        If the operator following the gather operation is sharded,
+        output gradients need to be reduce scattered and whereas
+        if the operator is duplicated, output gradients only need to be scattered.
 
     Returns
     -------

--- a/slapo/sharding/utils.py
+++ b/slapo/sharding/utils.py
@@ -206,7 +206,7 @@ def all_gather_forward_output(inp, dim, group, tensor_parallel_output_grad=True)
         The process group to all-gather.
     tensor_parallel_output_grad: bool
         If the operator following the gather operation is sharded,
-        output gradients need to be reduce scattered and whereas
+        output gradients need to be reduced and scattered; whereas
         if the operator is duplicated, output gradients only need to be scattered.
 
     Returns

--- a/slapo/sharding/utils.py
+++ b/slapo/sharding/utils.py
@@ -87,7 +87,7 @@ def reduce_scatter_along_dim(inp, dim, world_size, group):
     return ret
 
 
-def scatter_along_first_dim(inp, dim, world_size, group):
+def scatter_along_dim(inp, dim, world_size, group):
     """scatter along the given dimension.
 
     Paramters

--- a/slapo/sharding/utils.py
+++ b/slapo/sharding/utils.py
@@ -140,7 +140,7 @@ class _AllGatherForwardOutput(torch.autograd.Function):
         if tensor_parallel_output_grad:
             ret = reduce_scatter_along_dim(grad_output, dim, world_size, group)
         else:
-            ret = scatter_along_first_dim(grad_output, dim, world_size, group)
+            ret = scatter_along_dim(grad_output, dim, world_size, group)
 
         return (ret, None, None, None)
 
@@ -179,7 +179,7 @@ class _ScatterForwardOutput(torch.autograd.Function):
         ctx.group = group
         world_size = dist.get_world_size(group)
 
-        return scatter_along_first_dim(inp, dim, world_size, group)
+        return scatter_along_dim(inp, dim, world_size, group)
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/tests/end2end.py
+++ b/tests/end2end.py
@@ -31,7 +31,7 @@ def parse_log(impl, log_file):
     ("wideresnet-250M", "slapo-megatron", "1", "48", "512", "0.34"),
     ("wideresnet-250M", "slapo-deepspeed", "4", "256", "512", "0.67"),
     ("bert-large-uncased", "slapo-megatron", "2", "10", "512", "0"),
-    ("bert-large-uncased", "slapo-deepspeed", "2", "28", "512", "0"),
+    ("bert-large-uncased", "slapo-deepspeed", "2", "24", "512", "0"),
     ("EleutherAI/gpt-neo-125M", "slapo-megatron", "2", "1", "512", "1.0"),
     ("t5-base", "slapo-megatron", "4", "8", "1024", "0.67"),
 ])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR revises the sequence parallelism for GPT model and makes it optional. We add `tensor_parallel_output_grad` to indicate if the following operator after all-gather is sharded. If yes, we need to perform reduce-scatter during the backward and whereas a split is only needed for the following duplicate computation. 

For GPT model, we will first add sequence partition after embedding lookup and another all-gather after the final layer-norm because of `hidden_states = hidden_states.view(output_shape)` before returning it:
```
    if sequence_parallel:
        sch[word_embed_name].sync(mode="fwd_post", sync_op_or_fn="scatter", axis=1)
        sch[pos_embed_name].sync(mode="fwd_post", sync_op_or_fn="scatter", axis=1)
        sch[final_ln_name].sync(
            mode="fwd_post",
            sync_op_or_fn="all_gather",
            axis=1,
            tensor_parallel_output_grad=False,
        )
```

Inside the Transformer model, we will shard sequence dimension for both attention and FFN.

Attention:
```
            if sequence_parallel:
                sub_sch["module.FusedQKV_0.fused_linear"].sync(
                    mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
                )

                sub_sch["module.out_proj"].sync(
                    mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
                )
```
Here, we register all-gather before FusedQKV, because the input is sharded across sequence dimension. During its backward, a reduce-scatter is called on the input grads. We then add a reduce-scatter after the output layer to synchronize the partial activations, and an all-gather is invoked during the backward.

FFN:
```
            if sequence_parallel:
                sch[f"{prefix}.{fc_names[0]}"].sync(
                    mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
                )
                sch[f"{prefix}.{fc_names[1]}"].sync(
                    mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1
                )
```
Similarly, we add relevant all-gather and reduce-scatter to FFN part.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

