### PR TITLE
[Schedule] Fix linear bias after row sharding weight (#10)

### DIFF
--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -365,7 +365,6 @@ def deepspeed_pipe_engine(
     else:
         param_dtype = torch.float
 
-    # pylint: disable=unexpected-keyword-arg
     model = pipe.PipelineModule(
         stage_modules,
         topology=topology,

--- a/slapo/model_dialect/deepspeed/pipeline.py
+++ b/slapo/model_dialect/deepspeed/pipeline.py
@@ -365,6 +365,7 @@ def deepspeed_pipe_engine(
     else:
         param_dtype = torch.float
 
+    # pylint: disable=unexpected-keyword-arg
     model = pipe.PipelineModule(
         stage_modules,
         topology=topology,

--- a/slapo/op/linear.py
+++ b/slapo/op/linear.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn.parameter import Parameter
+
+
+class LinearWithSeparateBias(nn.Linear):
+    """Implementation modified from `nn.Linear`
+    This class is also inherited from `nn.Linear` to make sure it will be
+    treated as the same class when using `isinstance(...)` in `init_weights`
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        world_size: int,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super(LinearWithSeparateBias, self).__init__(
+            in_features, out_features, bias=False, device=device, dtype=dtype
+        )
+        self.world_size = world_size
+        self.bias = Parameter(torch.empty(out_features, **factory_kwargs))
+        self.reset_parameters()
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.linear(x, self.weight, None)
+        # Divide bias by world_size to avoid redundant summation in TP
+        x = x + self.bias / self.world_size
+        return x

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -455,10 +455,12 @@ class Schedule:
                                 self.mod.in_features,
                                 self.mod.out_features,
                                 self.world_size,
+                                self.group,
                                 self.mod.weight.device,
                                 self.mod.weight.dtype,
                             )
                             self.replace(new_mod)
+                        return
                 else:
                     raise ValueError(
                         f"Invalid sync_op_or_fn {sync_op_or_fn} for mode {mode} "

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -3,7 +3,7 @@
 
 """
 Test sharding primitive. Note that this test has to be invoked by torchrun. For example:
-torchrun --nproc_per_node 2 -m pytest test_shard.py
+torchrun --nproc_per_node 2 -m pytest -s tests/test_shard.py
 """
 # pylint: disable=unused-argument
 import os
@@ -148,7 +148,7 @@ def test_seq_para(init_dist):
         def __init__(self):
             super().__init__()
             self.linear1 = torch.nn.Linear(30, 30)
-            self.linear2 = torch.nn.Linear(30, 30, bias=False)
+            self.linear2 = torch.nn.Linear(30, 30)
 
         def forward(self, data):
             out = self.linear1(data)
@@ -196,7 +196,7 @@ def test_seq_para(init_dist):
         "linear1.weight": 0,
         "linear1.bias": 0,
         "linear2.weight": 1,
-        # "linear2.bias": -1,
+        "linear2.bias": -1,
     }
     path_and_grads = gather_grad(sch_model, param_path_and_gather_axis)
 

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -38,7 +38,11 @@ def gather_grad(model, param_path_and_gather_axis):
         param = model
         for token in path.split("."):
             param = getattr(param, token)
-        ret[path] = _gather_grad(param.grad, axis)
+        if axis != -1:
+            grad = _gather_grad(param.grad, axis)
+        else:
+            grad = param.grad
+        ret[path] = grad
     return ret
 
 
@@ -63,7 +67,10 @@ def gather_and_copy_model(src_model, dest_model, param_path_and_gather_axis):
         for token in path.split("."):
             part_param = getattr(part_param, token)
             dest_param = getattr(dest_param, token)
-        param = _gather_param(part_param, axis)
+        if axis != -1:
+            param = _gather_param(part_param, axis)
+        else:
+            param = part_param
         dest_param.data = param
 
 
@@ -91,7 +98,7 @@ def test_linear(init_dist):
             # FIXME: Enable bias results in incorrect results with sharding,
             # because when sharding the input dimension, bias should also
             # be scaled by world size,
-            self.linear2 = torch.nn.Linear(30, 40, bias=False)
+            self.linear2 = torch.nn.Linear(30, 40)
 
         def forward(self, data):
             out = self.linear1(data)
@@ -121,6 +128,7 @@ def test_linear(init_dist):
         "linear1.weight": 0,
         "linear1.bias": 0,
         "linear2.weight": 1,
+        "linear2.bias": -1,
     }
     path_and_grads = gather_grad(sch_model, param_path_and_gather_axis)
 

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -95,9 +95,6 @@ def test_linear(init_dist):
         def __init__(self):
             super().__init__()
             self.linear1 = torch.nn.Linear(20, 30)
-            # FIXME: Enable bias results in incorrect results with sharding,
-            # because when sharding the input dimension, bias should also
-            # be scaled by world size,
             self.linear2 = torch.nn.Linear(30, 40)
 
         def forward(self, data):
@@ -185,7 +182,6 @@ def test_seq_para(init_dist):
     )
 
     sch_model, _ = slapo.build(sch)
-    sch_model.cuda(local_rank)
 
     data = torch.randn((3, 16, 30), requires_grad=True).cuda(local_rank)
     dist.broadcast(data, src=0)

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -196,6 +196,7 @@ def test_seq_para(init_dist):
         "linear1.weight": 0,
         "linear1.bias": 0,
         "linear2.weight": 1,
+        # "linear2.bias": -1,
     }
     path_and_grads = gather_grad(sch_model, param_path_and_gather_axis)
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #10. It leverages Megatron-LM's method to delay the bias add after `all_reduce`, so that the bias will only be added once, and the gradients are proved to be the same as the original ones.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

