### PR TITLE
[Schedule] Add .fuse() primitive

### DIFF
--- a/examples/bert/schedule.py
+++ b/examples/bert/schedule.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from slapo import init_empty_weights
 from slapo.pattern import call_module
+from slapo.op.linear import FusedQKV
 
 
 def trace_attention(sch, config, attn_path="encoder.layer.N.attention"):
@@ -109,34 +110,6 @@ def replace_and_shard_attention(
             },
         )
 
-        class FusedQKV(nn.Module):
-            def __init__(self, hidden_size, num_heads) -> None:
-                super().__init__()
-                self.hidden_size = hidden_size
-                self.num_heads = num_heads
-                self.head_size = hidden_size // num_heads
-                self.fused_linear = nn.Linear(
-                    hidden_size, self.num_heads * self.head_size * 3
-                )
-
-            def reshape_for_scores(self, x):
-                new_x_shape = x.size()[:-1] + (
-                    self.num_heads // sch.world_size,
-                    self.head_size,
-                    3,
-                )
-                x = x.view(new_x_shape)
-                return x.contiguous()
-
-            def forward(self, hidden_states):
-                qkv = self.fused_linear(hidden_states)
-                reshaped_qkv = self.reshape_for_scores(qkv)
-                q, k, v = torch.split(reshaped_qkv, 1, dim=-1)
-                q = torch.squeeze(q, -1).contiguous()
-                k = torch.squeeze(k, -1).contiguous()
-                v = torch.squeeze(v, -1).contiguous()
-                return [q, k, v]
-
         def pattern(x: torch.Tensor) -> torch.Tensor:
             x = call_module("query|key|value", x)
             new_x_shape = x.size()[:-1] + (num_heads, hidden_size)
@@ -146,7 +119,7 @@ def replace_and_shard_attention(
         subgraphs = sub_sch["module"].find(pattern)
         assert len(subgraphs) == 3
         with init_empty_weights(enable=delay_init):
-            new_fused_qkv = FusedQKV(hidden_size, num_heads)
+            new_fused_qkv = FusedQKV(hidden_size, num_heads, sch.world_size)
         sub_sch["module"].replace(new_fused_qkv, subgraphs)
         if sch.world_size > 1:
             sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -10,6 +10,7 @@ from torch.distributed import distributed_c10d as dist
 import slapo
 from slapo import init_empty_weights
 from slapo.pattern import call_module
+from slapo.op.linear import FusedQKV
 
 
 def trace_attention(sch, config, attn_path="h.N.attn.attention"):
@@ -137,34 +138,6 @@ def replace_and_shard_attention(
             },
         )
 
-        class FusedQKV(nn.Module):
-            def __init__(self, hidden_size, num_heads) -> None:
-                super().__init__()
-                self.hidden_size = hidden_size
-                self.num_heads = num_heads
-                self.head_size = hidden_size // num_heads
-                self.fused_linear = nn.Linear(
-                    hidden_size, self.num_heads * self.head_size * 3
-                )
-
-            def reshape_for_scores(self, x):
-                new_x_shape = x.size()[:-1] + (
-                    self.num_heads // sch.world_size,
-                    self.head_size,
-                    3,
-                )
-                x = x.view(new_x_shape)
-                return x.contiguous()
-
-            def forward(self, hidden_states):
-                qkv = self.fused_linear(hidden_states)
-                reshaped_qkv = self.reshape_for_scores(qkv)
-                q, k, v = torch.split(reshaped_qkv, 1, dim=-1)
-                q = torch.squeeze(q, -1).contiguous()
-                k = torch.squeeze(k, -1).contiguous()
-                v = torch.squeeze(v, -1).contiguous()
-                return [q, k, v]
-
         def pattern(x: torch.Tensor) -> torch.Tensor:
             x = call_module("query|key|value", x)
             new_x_shape = x.size()[:-1] + (num_heads, hidden_size)
@@ -174,7 +147,7 @@ def replace_and_shard_attention(
         subgraphs = sub_sch["module"].find(pattern)
         assert len(subgraphs) == 3
         with init_empty_weights(enable=delay_init):
-            new_fused_qkv = FusedQKV(hidden_size, num_heads)
+            new_fused_qkv = FusedQKV(hidden_size, num_heads, sch.world_size)
         sub_sch["module"].replace(new_fused_qkv, subgraphs)
         if sch.world_size > 1:
             sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)

--- a/examples/opt/model.py
+++ b/examples/opt/model.py
@@ -12,8 +12,6 @@ from schedule import (
     remove_cast,
     replace_and_shard_mlp,
     replace_and_shard_attention,
-    replace_qkv,
-    shard_qkv,
     shard_word_embedding,
     trace_attention,
 )

--- a/examples/roberta/schedule.py
+++ b/examples/roberta/schedule.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from slapo import init_empty_weights
 from slapo.pattern import call_module
+from slapo.op.linear import FusedQKV
 
 
 def trace_attention(sch, config, attn_path="encoder.layer.N.attention"):
@@ -109,34 +110,6 @@ def replace_and_shard_attention(
             },
         )
 
-        class FusedQKV(nn.Module):
-            def __init__(self, hidden_size, num_heads) -> None:
-                super().__init__()
-                self.hidden_size = hidden_size
-                self.num_heads = num_heads
-                self.head_size = hidden_size // num_heads
-                self.fused_linear = nn.Linear(
-                    hidden_size, self.num_heads * self.head_size * 3
-                )
-
-            def reshape_for_scores(self, x):
-                new_x_shape = x.size()[:-1] + (
-                    self.num_heads // sch.world_size,
-                    self.head_size,
-                    3,
-                )
-                x = x.view(new_x_shape)
-                return x.contiguous()
-
-            def forward(self, hidden_states):
-                qkv = self.fused_linear(hidden_states)
-                reshaped_qkv = self.reshape_for_scores(qkv)
-                q, k, v = torch.split(reshaped_qkv, 1, dim=-1)
-                q = torch.squeeze(q, -1).contiguous()
-                k = torch.squeeze(k, -1).contiguous()
-                v = torch.squeeze(v, -1).contiguous()
-                return [q, k, v]
-
         def pattern(x: torch.Tensor) -> torch.Tensor:
             x = call_module("query|key|value", x)
             new_x_shape = x.size()[:-1] + (num_heads, hidden_size)
@@ -145,7 +118,7 @@ def replace_and_shard_attention(
 
         subgraphs = sub_sch["module"].find(pattern)
         assert len(subgraphs) == 3
-        new_fused_qkv = FusedQKV(hidden_size, num_heads)
+        new_fused_qkv = FusedQKV(hidden_size, num_heads, sch.world_size)
         sub_sch["module"].replace(new_fused_qkv, subgraphs)
         if sch.world_size > 1:
             sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)

--- a/examples/t5/schedule.py
+++ b/examples/t5/schedule.py
@@ -141,7 +141,7 @@ def replace_and_shard_attention(
                 def forward(self, hidden_states):
                     states = self.query(hidden_states)
                     states = self.reshape_for_scores(states)
-                    return [states]
+                    return states
 
             def pattern_kv(x: torch.Tensor) -> torch.Tensor:
                 x = call_module("key|value", x)
@@ -162,7 +162,7 @@ def replace_and_shard_attention(
                 return x
 
             subgraphs = sub_sch.find(pattern_q)
-            assert len(subgraphs) != 0
+            assert len(subgraphs) == 1
             with init_empty_weights(enable=delay_init):
                 new_q = ShardableQ(num_heads, hidden_size, d_kv)
             sub_sch.replace(new_q, subgraphs)

--- a/slapo/op/linear.py
+++ b/slapo/op/linear.py
@@ -1,9 +1,38 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
 from torch import nn
 import torch.nn.functional as F
 from torch import Tensor
+
+
+class FusedQKV(nn.Module):
+    def __init__(self, hidden_size, num_heads, world_size) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_size = hidden_size // num_heads
+        self.fused_linear = nn.Linear(hidden_size, self.num_heads * self.head_size * 3)
+        self.world_size = world_size
+
+    def reshape_for_scores(self, x):
+        new_x_shape = x.size()[:-1] + (
+            self.num_heads // self.world_size,
+            self.head_size,
+            3,
+        )
+        x = x.view(new_x_shape)
+        return x.contiguous()
+
+    def forward(self, hidden_states):
+        qkv = self.fused_linear(hidden_states)
+        reshaped_qkv = self.reshape_for_scores(qkv)
+        q, k, v = torch.split(reshaped_qkv, 1, dim=-1)
+        q = torch.squeeze(q, -1).contiguous()
+        k = torch.squeeze(k, -1).contiguous()
+        v = torch.squeeze(v, -1).contiguous()
+        return [q, k, v]
 
 
 class LinearWithSeparateBias(nn.Linear):

--- a/slapo/op/linear.py
+++ b/slapo/op/linear.py
@@ -5,6 +5,7 @@ from torch import nn
 import torch.nn.functional as F
 from torch import Tensor
 
+
 class LinearWithSeparateBias(nn.Linear):
     """Implementation modified from `nn.Linear`
     Arguments are the same as the inputs of `nn.Linear`

--- a/slapo/op/linear.py
+++ b/slapo/op/linear.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from torch import nn
+import torch.nn.functional as F
+from torch import Tensor
+
+class LinearWithSeparateBias(nn.Linear):
+    """Implementation modified from `nn.Linear`
+    Arguments are the same as the inputs of `nn.Linear`
+    """
+
+    # pylint: disable=arguments-renamed
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.linear(x, self.weight, None)
+        x = x + self.bias
+        return x

--- a/slapo/pattern.py
+++ b/slapo/pattern.py
@@ -9,5 +9,14 @@ class Pattern(nn.Module):
         raise NotImplementedError
 
 
+class CallModule(nn.Module):
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+
+    def forward(self, *args):
+        raise NotImplementedError
+
+
 def call_module(mod_name, *args):
     raise NotImplementedError

--- a/slapo/pattern.py
+++ b/slapo/pattern.py
@@ -9,7 +9,7 @@ class Pattern(nn.Module):
         raise NotImplementedError
 
 
-class CallModule(nn.Module):
+class ModulePattern(nn.Module):
     def __init__(self, name):
         super().__init__()
         self.name = name

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -41,7 +41,7 @@ from .initialization import init_empty_weights
 from .op.linear import LinearWithSeparateBias
 from .utils.common import transfer_hooks, is_lambda_function
 from .utils.mapping import MAPPING_FROM_FUNCTIONAL_TO_MODULE
-from .pattern import Pattern, CallModule, call_module
+from .pattern import Pattern, ModulePattern, call_module
 
 logger = get_logger()
 
@@ -609,7 +609,7 @@ class Schedule:
                     curr.op == "call_module"
                     and target.op == "call_module"
                     and isinstance(
-                        dict(pattern_mod.named_modules())[target.target], CallModule
+                        dict(pattern_mod.named_modules())[target.target], ModulePattern
                     )
                     and re.match(
                         dict(pattern_mod.named_modules())[target.target].name,
@@ -680,8 +680,9 @@ class SubgraphWrapper(nn.Module):
                 pattern_wrapper,
                 recursive=True,
                 flatten=True,
-                leaf_modules=["CallModule"],
+                leaf_modules=["ModulePattern"],
             )
+        assert isinstance(pattern_mod, fx.GraphModule)
 
         first_op = None
         for target_node in list(pattern_mod.graph.nodes):

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -746,6 +746,9 @@ class SubgraphWrapper(nn.Module):
         subgraphs : Optional[List[Tuple[str, torch.fx.Node]]]
             The list of subgraphs to replace. Each subgraph is a tuple of
             (module_name, node). If it is None, replace the whole module.
+        name : Optional[str]
+            The name of the replaced module. If it is None, a default name
+            will be automatically generated.
         """
         if subgraphs is None:
             # If subgraphs is None, replace the whole self module and the schedule.

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -911,6 +911,25 @@ class SubgraphWrapper(nn.Module):
         new_mod = torch.jit.script(new_gm)
         self.replace(new_mod, subgraph, name)
 
+    # def decompose(self):
+    #     if not isinstance(self.mod, nn.Linear):
+    #         raise RuntimeError("Can only support decomposing a nn.Linear layer for now")
+    #     # Replace the linear module
+    #     with init_empty_weights(
+    #         enable=(sch.mod.weight.device == torch.device("meta"))
+    #     ):
+    #         new_mod = LinearWithSeparateBias(
+    #             sch.mod.weight.shape[1],
+    #             sch.mod.weight.shape[0],
+    #             sync_fn,
+    #             sch.mod.weight.device,
+    #             sch.mod.weight.dtype,
+    #         )
+    #         new_mod.in_features = sch.mod.in_features
+    #         new_mod.out_features = sch.mod.out_features
+    #         sch.replace(new_mod)
+    #     self.replace()
+
     @register_primitive()
     def checkpoint(self, order_args_fn=None):
         class CheckPointWrapper(nn.Module):

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -40,6 +40,8 @@ from .tracer import trace as trace_module
 from .utils.common import transfer_hooks, is_lambda_function
 from .utils.mapping import MAPPING_FROM_FUNCTIONAL_TO_MODULE
 from .pattern import Pattern, call_module
+from .initialization import init_empty_weights
+from .op.linear import LinearWithSeparateBias
 
 logger = get_logger()
 
@@ -733,7 +735,7 @@ class SubgraphWrapper(nn.Module):
             node.replace_all_uses_with(new_node)
         self.mod.graph.erase_node(node)
 
-    def replace_module(self, new_mod, subgraphs=None):
+    def replace_module(self, new_mod, subgraphs=None, name=None):
         """Replace an entire module with a new one.
         Do NOT directly call this function, use `.replace()` instead.
 
@@ -911,24 +913,31 @@ class SubgraphWrapper(nn.Module):
         new_mod = torch.jit.script(new_gm)
         self.replace(new_mod, subgraph, name)
 
-    # def decompose(self):
-    #     if not isinstance(self.mod, nn.Linear):
-    #         raise RuntimeError("Can only support decomposing a nn.Linear layer for now")
-    #     # Replace the linear module
-    #     with init_empty_weights(
-    #         enable=(sch.mod.weight.device == torch.device("meta"))
-    #     ):
-    #         new_mod = LinearWithSeparateBias(
-    #             sch.mod.weight.shape[1],
-    #             sch.mod.weight.shape[0],
-    #             sync_fn,
-    #             sch.mod.weight.device,
-    #             sch.mod.weight.dtype,
-    #         )
-    #         new_mod.in_features = sch.mod.in_features
-    #         new_mod.out_features = sch.mod.out_features
-    #         sch.replace(new_mod)
-    #     self.replace()
+    @register_primitive()
+    def decompose(self):
+        if not isinstance(self.mod, nn.Linear):
+            raise RuntimeError(
+                "Can only support decomposing a `nn.Linear` layer for now"
+            )
+        if (
+            self.mod.weight.shape[1] != self.mod.in_features
+            or self.mod.weight.shape[0] != self.mod.out_features
+        ):
+            raise RuntimeError(".shard() should be applied after .decompose()")
+        # Replace the linear module
+        with init_empty_weights(
+            enable=(self.mod.weight.device == torch.device("meta"))
+        ):
+            new_mod = LinearWithSeparateBias(
+                self.mod.weight.shape[1],
+                self.mod.weight.shape[0],
+                device=self.mod.weight.device,
+                dtype=self.mod.weight.dtype,
+            )
+            # Use original value
+            new_mod.weight = self.mod.weight
+            new_mod.bias = self.mod.bias
+            self.replace(new_mod)
 
     @register_primitive()
     def checkpoint(self, order_args_fn=None):

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -756,7 +756,7 @@ class SubgraphWrapper(nn.Module):
 
             self.mod = new_sch.mod
             self.child = new_sch.child
-            for name, sch in self.child.items():
+            for _, sch in self.child.items():
                 sch.parent = self
             if self.parent:
                 self.update_submodule(self.parent.mod, self.name, new_mod)
@@ -864,7 +864,7 @@ class SubgraphWrapper(nn.Module):
             value_remap[node] = new_graph.node_copy(node, lambda n: value_remap[n])
         # Return output from new graph
         new_graph.output(value_remap[path_and_nodes[-1][1]])
-        new_gm = fx.GraphModule(dict(), new_graph)
+        new_gm = fx.GraphModule({}, new_graph)
         new_mod = torch.jit.script(new_gm)
         self.replace(new_mod, subgraph, name)
 

--- a/slapo/utils/mapping.py
+++ b/slapo/utils/mapping.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 MAPPING_FROM_FUNCTIONAL_TO_MODULE: Dict[Callable, Callable] = {
     F.embedding: nn.Embedding,
     F.layer_norm: nn.LayerNorm,
+    F.dropout: nn.Dropout,
     F.group_norm: nn.GroupNorm,
     F.linear: nn.Linear,
     F.relu: nn.ReLU,

--- a/slapo/utils/mapping.py
+++ b/slapo/utils/mapping.py
@@ -14,6 +14,7 @@ MAPPING_FROM_FUNCTIONAL_TO_MODULE: Dict[Callable, Callable] = {
     F.group_norm: nn.GroupNorm,
     F.linear: nn.Linear,
     F.relu: nn.ReLU,
+    F.gelu: nn.GELU,
     F.conv1d: nn.Conv1d,
     F.conv2d: nn.Conv2d,
     F.mse_loss: nn.MSELoss,

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test fusion."""
+
+import pytest
+import copy
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import slapo
+
+
+def test_vertical_fusion():
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 32, 3)
+
+        def forward(self, x):
+            x = self.conv(x)
+            x = F.relu(x)
+            x = x + 1
+            return x
+
+    mod = Model().cuda()
+    sch = slapo.create_schedule(copy.deepcopy(mod))
+
+    def pattern(x: torch.Tensor):
+        x = F.relu(x)
+        x = x + 1
+        return x
+
+    subgraph = sch.find("conv", pattern, include_start_op=False)
+    sch.fuse(subgraph)
+
+    sch_model, _ = slapo.build(sch, init_weights=False)
+    print(sch_model)
+
+    inp = torch.randn((1, 3, 32, 32), requires_grad=True).cuda()
+    out = sch_model(inp)
+    out_ref = mod(inp)
+    torch.testing.assert_close(out, out_ref)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test operator fusion."""
 
-import pytest
 import copy
+import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 import torch.nn.functional as F
 
 import slapo

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Test operator fusion."""
 
+# pylint: disable=comparison-with-callable
 import copy
-import pytest
 import operator
+import pytest
+
 import torch
 from torch import nn
 import torch.nn.functional as F

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Test fusion."""
+"""Test operator fusion."""
 
 import pytest
 import copy
@@ -32,7 +32,7 @@ def test_vertical_fusion():
         return x
 
     subgraph = sch.find("conv", pattern, include_start_op=False)
-    sch.fuse(subgraph)
+    sch.fuse(subgraph, compiler="TorchScript", name="FusedReLU")
 
     sch_model, _ = slapo.build(sch, init_weights=False)
     print(sch_model)

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -32,6 +32,7 @@ def test_exact_match():
 
     subgraph = sch.find(pattern)[0]
     assert len(subgraph) == 2
+    # pylint: disable=comparison-with-callable
     assert subgraph[0][1].target == F.relu
     assert subgraph[1][1].target == operator.add
 
@@ -225,6 +226,58 @@ def test_horizontal_pattern():
     assert subgraph[1][0][1].target == "k_proj"
     assert subgraph[2][0][1].target == "v_proj"
     assert subgraph[0][1][1].target == "permute"
+
+
+class LeNet5(nn.Module):
+    def __init__(self, num_classes):
+        super().__init__()
+        self.layer1 = nn.Sequential(
+            nn.Conv2d(1, 6, kernel_size=5, stride=1, padding=0),
+            nn.BatchNorm2d(6),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+        self.layer2 = nn.Sequential(
+            nn.Conv2d(6, 16, kernel_size=5, stride=1, padding=0),
+            nn.BatchNorm2d(16),
+            nn.ReLU(),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+        self.fc = nn.Linear(400, 120)
+        self.relu = nn.ReLU()
+        self.fc1 = nn.Linear(120, 84)
+        self.relu1 = nn.ReLU()
+        self.fc2 = nn.Linear(84, num_classes)
+
+    def forward(self, x):
+        out = self.layer1(x)
+        out = self.layer2(out)
+        out = out.reshape(out.size(0), -1)
+        out = self.fc(out)
+        out = self.relu(out)
+        out = self.fc1(out)
+        out = self.relu1(out)
+        out = self.fc2(out)
+        return out
+
+
+def test_whole_model_matching():
+    sch = slapo.create_schedule(LeNet5(10))
+
+    class ReLUBNPattern(slapo.Pattern):
+        def __init__(self):
+            super().__init__()
+            self.bn = nn.BatchNorm2d(16)
+            self.relu = nn.ReLU()
+
+        # pylint: disable=arguments-differ
+        def forward(self, x: torch.Tensor):
+            return self.relu(self.bn(x))
+
+    subgraph = sch["layer2"].find("0", ReLUBNPattern(), include_start_op=False)[0]
+    assert len(subgraph) == 2
+    assert isinstance(sch["layer2"].get_module(subgraph[0][1].target), nn.BatchNorm2d)
+    assert isinstance(sch["layer2"].get_module(subgraph[1][1].target), nn.ReLU)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds a new primitive called `.fuse(subgraph, compiler)` for operator fusion. Currently we only support pattern-based [vertical operator fusion](https://sisyphus.gitbook.io/project/deep-learning-basics/computation-graph-optimization/tensorrt-computation-graph-optimization) using TorchScript as the backend compiler. A simple example is shown below.

```python
class Model(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv = nn.Conv2d(3, 32, 3)

    def forward(self, x):
        x = self.conv(x)
        x = F.relu(x)
        x = x + 1
        return x

mod = Model()
sch = slapo.create_schedule(mod)

# Define a function pattern whose ops will be fused
def pattern(x: torch.Tensor):
    x = F.relu(x)
    x = x + 1
    return x

# Find the subgraph in the original module that matches the specified pattern
subgraph = sch.find(pattern)
# Fuse the subgraph
sch.fuse(subgraph, compiler="TorchScript", name="FusedReLU")
```



The fusion performance needs to be tested. As I first create an identical torch.fx subgraph and pass it into TorchScript's scripting mode for optimization, it may cause performance issue if some of the operators are not recognized by TorchScript. Tracing mode can achieve the best performance but it is hard to leverage since we cannot always obtain example inputs for each subgraph. Scripting a user-defined function is also not a good approach since the backward pass is not captured by TorchScript. Therefore, only scripting an entire module is a good fit for our case, and we need to test the compatibility of torch.fx and TorchScript.

## Checklist ##

- [x] Support using op in `torch.nn.functional` to match modules in `torch.nn`. For example, `F.relu` and `nn.ReLU` should be treated as the same in pattern matching, since users cannot specify a module in a function pattern. (#35)
- [x] Support subgraph matching with multiple input arguments. (#35)
- [x] Add `.decompose()` primitive and support decoupling bias from `nn.Linear`
- [x] Support generate a flattened traced graph (#29)
- [x] Fuse the decomposed bias with consequential operators, e.g. bias+GeLU.

## Future plan (Updated) ##
The following features will be added in separate PRs.
* Subgraph matching with multiple input arguments (#35)
* Extensible compiler backend (e.g., TVM)
* Rule-based subgraph matching (#35), probably needs more use cases and testings