### PR TITLE
[Schedule][replace] Transfer hooks when replacing modules

### DIFF
--- a/scripts/lint/pylintrc
+++ b/scripts/lint/pylintrc
@@ -200,7 +200,7 @@ redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=88
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -9,6 +9,7 @@ from torch.fx.passes.split_module import split_module
 
 from .logger import get_logger
 from .model_dialect import get_dialect_cls
+from .utils.common import transfer_hooks
 
 logger = get_logger()
 
@@ -424,6 +425,10 @@ def build_pipeline_model(sch, target, **kwargs):
                 stage_id_2_arg_names,
             )
         )
+
+    # Transfer hooks from the original module to the corresponding pipeline stage.
+    transfer_hooks(res_partition[0], partitioned_mod, ["fwd_pre", "bwd_post"])
+    transfer_hooks(res_partition[-1], partitioned_mod, ["fwd_post"])
 
     pipe_engine_fn = get_dialect_cls("pipeline_engine", target)
     return pipe_engine_fn(

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -29,7 +29,7 @@ def get_hooks(mod):
     return hooks
 
 
-def transfer_hooks(old_mod, new_mod):
+def transfer_hooks(old_mod, new_mod, hook_types=None):
     """Transfer the hooks from old_mod to new_mod.
 
     Parameters
@@ -38,12 +38,18 @@ def transfer_hooks(old_mod, new_mod):
         The old module.
     new_mod : torch.nn.Module
         The new module.
+    hook_types : Optional[List[str]]
+        The types of hooks to transfer. If None, transfer all hooks.
     """
-    for hook in old_mod._forward_hooks.values():
-        new_mod.register_forward_hook(hook)
+    HOOK_TYPE_TO_ATTR = {
+        "fwd_pre": ("_forward_pre_hooks", "register_forward_pre_hook"),
+        "fwd_post": ("_forward_hooks", "register_forward_hook"),
+        "bwd_post": ("_backward_hooks", "register_backward_hook"),
+    }
+    if hook_types is None:
+        hook_types = ["fwd_pre", "fwd_post", "bwd_post"]
 
-    for hook in old_mod._forward_pre_hooks.values():
-        new_mod.register_forward_pre_hook(hook)
-
-    for hook in old_mod._backward_hooks.values():
-        new_mod.register_backward_hook(hook)
+    hook_attrs = [HOOK_TYPE_TO_ATTR[hook_type] for hook_type in hook_types]
+    for hook_attr, register_attr in hook_attrs:
+        for hook in getattr(old_mod, hook_attr).values():
+            getattr(new_mod, register_attr)(hook)

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Common utilities used in schedule."""
+
+
+def get_hooks(mod):
+    """Get the hooks of a module.
+
+    Parameters
+    ----------
+    mod : torch.nn.Module
+        The module.
+
+    Returns
+    -------
+    dict
+        A dictionary of hooks.
+    """
+    hooks = {"fwd_pre": [], "fwd_post": [], "bwd_post": []}
+    for hook in mod._forward_hooks.values():
+        hooks["fwd_post"].append(hook)
+
+    for hook in mod._forward_pre_hooks.values():
+        hooks["fwd_pre"].append(hook)
+
+    for hook in mod._backward_hooks.values():
+        hooks["bwd_post"].append(hook)
+
+    return hooks
+
+
+def transfer_hooks(old_mod, new_mod):
+    """Transfer the hooks from old_mod to new_mod.
+
+    Parameters
+    ----------
+    old_mod : torch.nn.Module
+        The old module.
+    new_mod : torch.nn.Module
+        The new module.
+    """
+    for hook in old_mod._forward_hooks.values():
+        new_mod.register_forward_hook(hook)
+
+    for hook in old_mod._forward_pre_hooks.values():
+        new_mod.register_forward_pre_hook(hook)
+
+    for hook in old_mod._backward_hooks.values():
+        new_mod.register_backward_hook(hook)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test replace primitives."""
+import pytest
+
+from torch import nn
+
+import slapo
+from slapo.utils.common import get_hooks
+
+
+def test_transfer_hook():
+    """Test whether the hooks are transferred to the new replaced module."""
+    # pylint: disable=unused-argument
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(10, 10)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = Model()
+
+    def fwd_pre_hook(mod, inp):
+        return inp
+
+    def fwd_post_hook(mod, inp, out):
+        return out
+
+    def bwd_post_hook(mod, grad_inp, grad_out):
+        return grad_inp
+
+    sch = slapo.create_schedule(model)
+
+    # Directly register hooks instead of using .sync, because
+    # we do not want to test .sync in this test.
+    sch.mod.register_forward_pre_hook(fwd_pre_hook)
+    sch.mod.register_forward_hook(fwd_post_hook)
+    sch.mod.register_backward_hook(bwd_post_hook)
+    all_hooks = get_hooks(sch.mod)
+    assert len(all_hooks["fwd_pre"]) == 1
+    assert len(all_hooks["fwd_post"]) == 1
+    assert len(all_hooks["bwd_post"]) == 1
+
+    sch.trace()
+
+    all_hooks = get_hooks(sch.mod)
+    assert len(all_hooks["fwd_pre"]) == 1
+    assert len(all_hooks["fwd_post"]) == 1
+    assert len(all_hooks["bwd_post"]) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The current `.trace` did the following two steps:
1. trace the target module to be a GraphModule.
2. replace the original module with the new GraphModule.

However, the traced GraphModule won't include any hooks in the original module, so the `.sync` primitives specified before tracing, including `.trace` and `.trace_for_pipeline` are dropped. This PR fixes this issue by transferring all hooks from the original module to the new one. For example, a hook registered to broadcast inputs will be transferred 2 times during scheduling:

1. After tracing the top module, the hook is transferred from the original module to the traced module.
2. After wrapping pipeline stage to partitioned modules, the (pre-forward) hook is transferred from the original module to the first pipeline stage module (wrapped by Slapo pipeline module). 

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac @chhzh123 