### PR TITLE
[Benchmark] Fix ZeRO-3 step log

### DIFF
--- a/benchmark/bench_single_node.py
+++ b/benchmark/bench_single_node.py
@@ -210,6 +210,9 @@ def parse_args():
         default="",
         help="Append the results to a file",
     )
+    common_parser.add_argument(
+        "--steps", type=int, default=40, help="Benchmark steps. Default: 40"
+    )
 
     parser = argparse.ArgumentParser()
     subprasers = parser.add_subparsers(
@@ -467,6 +470,7 @@ def main():
                     args.seq_len,
                     args.seq_len_dec,
                     impl=args.impl,
+                    steps=args.steps,
                     grad_ckpt=args.gradient_checkpoint,
                     fp16=args.dtype == "fp16",
                     gpus=gpus,

--- a/examples/albert/deepspeed_hf.py
+++ b/examples/albert/deepspeed_hf.py
@@ -180,7 +180,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/albert/deepspeed_hf.py
+++ b/examples/albert/deepspeed_hf.py
@@ -16,7 +16,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -180,11 +180,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/bert/deepspeed_hf.py
+++ b/examples/bert/deepspeed_hf.py
@@ -16,7 +16,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -201,11 +201,10 @@ def train(args):
             logger.info(f"end iter {idx}", ranks=0)
 
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/bert/deepspeed_hf.py
+++ b/examples/bert/deepspeed_hf.py
@@ -201,7 +201,12 @@ def train(args):
             logger.info(f"end iter {idx}", ranks=0)
 
     else:
-        train_with_torch(model, loader, steps=num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -196,7 +196,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, steps=num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -19,7 +19,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -196,11 +196,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/opt/deepspeed_hf.py
+++ b/examples/opt/deepspeed_hf.py
@@ -16,7 +16,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -182,11 +182,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/opt/deepspeed_hf.py
+++ b/examples/opt/deepspeed_hf.py
@@ -182,7 +182,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/roberta/deepspeed_hf.py
+++ b/examples/roberta/deepspeed_hf.py
@@ -16,7 +16,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -182,11 +182,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/roberta/deepspeed_hf.py
+++ b/examples/roberta/deepspeed_hf.py
@@ -182,7 +182,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/t5/deepspeed_hf.py
+++ b/examples/t5/deepspeed_hf.py
@@ -16,7 +16,7 @@ from slapo.utils.report import report_memory
 
 from model import schedule_model
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
     generate_pipeline_cuts,
@@ -190,11 +190,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/t5/deepspeed_hf.py
+++ b/examples/t5/deepspeed_hf.py
@@ -190,7 +190,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, steps=num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -92,32 +92,51 @@ def generate_pipeline_cuts(num_layers, num_pp, is_encoder_decoder=False):
 def train_with_torch(
     model,
     dataloader,
-    optimizer=None,
+    optimizer,
     preproc=None,
     postproc=None,
-    global_steps=40,
-    micro_batch_size=1,
+    steps=40,
 ):
-    """The training loop for DeepSpeedEngine and PyTorch runtime."""
-    is_deepspeed = hasattr(model, "backward")
-    if not is_deepspeed and optimizer is None:
-        raise ValueError("optimizer must be provided for PyTorch runtime")
+    """The training loop for PyTorch runtime. Note that this simple training loop
+    assumes no data parallelism and gradient accumulation.
+    """
 
     for step, batch in enumerate(dataloader):
         inputs, labels = preproc(step, batch) if preproc is not None else batch
         loss = model(*inputs, labels=labels).loss
-        if is_deepspeed:
-            model.backward(loss)
-            model.step()
-        else:
-            loss.backward()
-            optimizer.step()
+        loss.backward()
+        optimizer.step()
         loss = postproc(step, loss) if postproc is not None else loss
 
-        global_step = step // micro_batch_size
-        if step % micro_batch_size == 0 and global_step % 10 == 0:
-            logger.info(f"step {step // micro_batch_size} loss: {loss.item()}", ranks=0)
+        if step % 10 == 0:
+            logger.info(f"step {step} loss: {loss.item()}", ranks=0)
 
         loss = None
-        if global_step >= global_steps:
+        if step >= steps:
+            break
+
+
+def train_with_deepspeed_engine(
+    model,
+    dataloader,
+    preproc=None,
+    postproc=None,
+    steps=40,
+):
+    """The training loop for DeepSpeedEngine (without pipeline)."""
+
+    for micro_batch_step, batch in enumerate(dataloader):
+        inputs, labels = (
+            preproc(micro_batch_step, batch) if preproc is not None else batch
+        )
+        loss = model(*inputs, labels=labels).loss
+        model.backward(loss)
+        model.step()
+        loss = postproc(micro_batch_step, loss) if postproc is not None else loss
+
+        if model.global_steps % 10 == 0 and model.is_gradient_accumulation_boundary():
+            logger.info(f"step {model.global_steps} loss: {loss.item()}", ranks=0)
+
+        loss = None
+        if model.global_steps >= steps:
             break

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -93,6 +93,7 @@ def train_with_torch(
     model,
     dataloader,
     optimizer,
+    loss_fn=None,
     preproc=None,
     postproc=None,
     steps=40,
@@ -103,7 +104,10 @@ def train_with_torch(
 
     for step, batch in enumerate(dataloader):
         inputs, labels = preproc(step, batch) if preproc is not None else batch
-        loss = model(*inputs, labels=labels).loss
+        if loss_fn is None:
+            loss = model(*inputs, labels=labels).loss
+        else:
+            loss = loss_fn(model(*inputs).logits, labels)
         loss.backward()
         optimizer.step()
         loss = postproc(step, loss) if postproc is not None else loss
@@ -119,6 +123,7 @@ def train_with_torch(
 def train_with_deepspeed_engine(
     model,
     dataloader,
+    loss_fn=None,
     preproc=None,
     postproc=None,
     steps=40,
@@ -129,7 +134,10 @@ def train_with_deepspeed_engine(
         inputs, labels = (
             preproc(micro_batch_step, batch) if preproc is not None else batch
         )
-        loss = model(*inputs, labels=labels).loss
+        if loss_fn is None:
+            loss = model(*inputs, labels=labels).loss
+        else:
+            loss = loss_fn(model(*inputs).logits, labels)
         model.backward(loss)
         model.step()
         loss = postproc(micro_batch_step, loss) if postproc is not None else loss

--- a/examples/wideresnet/deepspeed_hf.py
+++ b/examples/wideresnet/deepspeed_hf.py
@@ -143,7 +143,12 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(model, loader, steps=num_iters)
+        train_with_torch(
+            model,
+            loader,
+            global_steps=num_iters,
+            micro_batch_size=micro_batch_size,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/wideresnet/deepspeed_hf.py
+++ b/examples/wideresnet/deepspeed_hf.py
@@ -18,7 +18,7 @@ from slapo.utils.report import report_memory
 from model import schedule_model, get_model_config, get_model
 from utils import count_parameters, get_data_loader
 from examples.utils import (
-    train_with_torch,
+    train_with_deepspeed_engine,
     get_ds_config,
     create_dist_group_for_pipeline,
 )
@@ -143,11 +143,10 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
-        train_with_torch(
+        train_with_deepspeed_engine(
             model,
             loader,
-            global_steps=num_iters,
-            micro_batch_size=micro_batch_size,
+            steps=num_iters,
         )
 
 

--- a/examples/wideresnet/megatron_hf.py
+++ b/examples/wideresnet/megatron_hf.py
@@ -171,7 +171,7 @@ def main():
         optimizer,
         preproc=preproc,
         postproc=postproc,
-        global_steps=train_iters,
+        steps=train_iters,
     )
 
 

--- a/examples/wideresnet/megatron_hf.py
+++ b/examples/wideresnet/megatron_hf.py
@@ -166,7 +166,12 @@ def main():
 
     timers("interval-time").start()
     train_with_torch(
-        model, loader, optimizer, preproc=preproc, postproc=postproc, steps=train_iters
+        model,
+        loader,
+        optimizer,
+        preproc=preproc,
+        postproc=postproc,
+        global_steps=train_iters,
     )
 
 

--- a/slapo/model_dialect/deepspeed/utils.py
+++ b/slapo/model_dialect/deepspeed/utils.py
@@ -33,9 +33,12 @@ class DeepSpeedLogParser:
         # 1. Every 10 steps, DeepSpeed reports the average samples/sec from beginning.
         # 2. We remove the first value (of the first 10 steps) as the warmup.
         n_records = len(samples_per_sec)
-        avg_samples_per_sec = (
-            samples_per_sec[-1] * 10 * n_records - samples_per_sec[0] * 10
-        ) / (10 * (n_records - 1))
+        if n_records > 1:
+            avg_samples_per_sec = (
+                samples_per_sec[-1] * 10 * n_records - samples_per_sec[0] * 10
+            ) / (10 * (n_records - 1))
+        else:
+            avg_samples_per_sec = samples_per_sec[0]
 
         gpu_mem = query("MaxMemAllocated")
 

--- a/tests/end2end.py
+++ b/tests/end2end.py
@@ -48,6 +48,7 @@ def test_end2end(model, impl, n_gpu, batch_size, seq_len, ckpt_ratio):
         cmd += " --seq-len-dec 512"
     cmd += f" --batch-size {batch_size}"
     cmd += f" --gradient-checkpoint {ckpt_ratio}"
+    cmd += " --steps 10"
     cmd += " > run_script.log 2>&1"
     print(cmd, flush=True)
     os.system(cmd)


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Fix the benchmark utility `train_with_torch` to consider micro batch when printing the log. Now it accepts optional `micro_batch_size` and only prints the loss per global batch.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @zarzen 