### PR TITLE
[Bugfix] Fix for sharding TP only

### DIFF
--- a/examples/albert/deepspeed_hf.py
+++ b/examples/albert/deepspeed_hf.py
@@ -101,7 +101,7 @@ def train(args):
     if enable_pipeline:
         # FIXME: is mbs=1 correct?
         batch_size = 16 if batch_size is None else batch_size
-        ds_config_dict = get_ds_config(batch_size, 1, True, False, "Pipeline")
+        ds_config_dict = get_ds_config(batch_size, 1, True, 0, "Pipeline")
         loss_fct = ParallelCrossEntropy(group=group)
 
         def loss_fn(outputs, labels):
@@ -127,9 +127,7 @@ def train(args):
             batch_size = micro_batch_size * args.world_size
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
-        ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, True, "ZeRO-3"
-        )
+        ds_config_dict = get_ds_config(batch_size, micro_batch_size, True, 3, "ZeRO-3")
         model, _ = slapo.build(
             sch,
             topology=topology,

--- a/examples/bert/deepspeed_hf.py
+++ b/examples/bert/deepspeed_hf.py
@@ -115,7 +115,7 @@ def train(args):
         batch_size = 32 if batch_size is None else batch_size
         micro_batch_size = 8 if micro_batch_size is None else micro_batch_size
         ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, False, "Pipeline"
+            batch_size, micro_batch_size, True, 0, "Pipeline"
         )
         loss_fct = ParallelCrossEntropy(group=group)
 
@@ -142,9 +142,7 @@ def train(args):
             batch_size = micro_batch_size * args.world_size
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
-        ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, True, "ZeRO-3"
-        )
+        ds_config_dict = get_ds_config(batch_size, micro_batch_size, True, 3, "ZeRO-3")
         model, _ = slapo.build(
             sch,
             topology=topology,

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -215,10 +215,13 @@ def train(args):
         for _ in range(num_iters):
             model.train_batch(data_iter=data_iter)
     else:
+        # use the Parallel Loss
+        loss_fn = None if args.tmp == 1 else loss_fn
         train_with_deepspeed_engine(
             model,
             loader,
             steps=num_iters,
+            loss_fn=loss_fn,
         )
 
 

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -184,8 +184,6 @@ def train(args):
             config=ds_config_dict,
             init_weights=model._init_weights,
         )
-        if args.tmp > 1:
-            model.loss_fn = loss_fn
         model = model.to(device)
     report_memory(msg="After building model")
 

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -5,7 +5,7 @@ import inspect
 
 import torch
 import torch.nn as nn
-import torch.distributed.distributed_c10d as dist
+from torch.distributed import distributed_c10d as dist
 
 import slapo
 from slapo import init_empty_weights

--- a/examples/opt/deepspeed_hf.py
+++ b/examples/opt/deepspeed_hf.py
@@ -101,7 +101,7 @@ def train(args):
     if enable_pipeline:
         # FIXME: is mbs=1 correct?
         batch_size = 16 if batch_size is None else batch_size
-        ds_config_dict = get_ds_config(batch_size, 1, True, False, "Pipeline")
+        ds_config_dict = get_ds_config(batch_size, 1, True, 0, "Pipeline")
         loss_fct = ParallelCrossEntropy(group=group)
 
         def loss_fn(outputs, labels):
@@ -128,9 +128,7 @@ def train(args):
             batch_size = micro_batch_size * args.world_size
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
-        ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, True, "ZeRO-3"
-        )
+        ds_config_dict = get_ds_config(batch_size, micro_batch_size, True, 3, "ZeRO-3")
         model, _ = slapo.build(
             sch,
             topology=topology,

--- a/examples/roberta/deepspeed_hf.py
+++ b/examples/roberta/deepspeed_hf.py
@@ -101,7 +101,7 @@ def train(args):
     if enable_pipeline:
         # FIXME: is mbs=1 correct?
         batch_size = 32 if batch_size is None else batch_size
-        ds_config_dict = get_ds_config(batch_size, 1, True, False, "Pipeline")
+        ds_config_dict = get_ds_config(batch_size, 1, True, 0, "Pipeline")
         loss_fct = ParallelCrossEntropy(group=group)
 
         def loss_fn(outputs, labels):
@@ -128,9 +128,7 @@ def train(args):
             batch_size = micro_batch_size * args.world_size
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
-        ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, True, "ZeRO-3"
-        )
+        ds_config_dict = get_ds_config(batch_size, micro_batch_size, True, 3, "ZeRO-3")
         model, _ = slapo.build(
             sch,
             topology=topology,

--- a/examples/t5/deepspeed_hf.py
+++ b/examples/t5/deepspeed_hf.py
@@ -100,7 +100,7 @@ def train(args):
     if enable_pipeline:
         # FIXME: is mbs=1 correct?
         batch_size = 16 if batch_size is None else batch_size
-        ds_config_dict = get_ds_config(batch_size, 1, True, False, "Pipeline")
+        ds_config_dict = get_ds_config(batch_size, 1, True, 0, "Pipeline")
         loss_fct = ParallelCrossEntropy(group=group)
 
         def loss_fn(outputs, labels):
@@ -127,9 +127,7 @@ def train(args):
             batch_size = micro_batch_size * args.world_size
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
-        ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, True, True, "ZeRO-3"
-        )
+        ds_config_dict = get_ds_config(batch_size, micro_batch_size, True, 3, "ZeRO-3")
         model, _ = slapo.build(
             sch,
             topology=topology,

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -12,7 +12,7 @@ _groups = []
 
 
 def get_ds_config(
-    batch_size, micro_batch_size_per_gpu, fp16=True, zero3=False, desc="", bf16=False
+    batch_size, micro_batch_size_per_gpu, fp16=True, zero_stage=0, desc="", bf16=False
 ):
     # https://github.com/microsoft/DeepSpeed/blob/ff42743/tests/unit/model_parallelism/test_configurable_parallel_pp.py#L20
     logger.info(f"fp16={fp16}, bf16={bf16}")
@@ -27,10 +27,10 @@ def get_ds_config(
         "train_micro_batch_size_per_gpu": micro_batch_size_per_gpu,
     }
 
-    if zero3:
-        zero3_config_dict = {
+    if zero_stage > 0:
+        zero_config_dict = {
             "zero_optimization": {
-                "stage": 3,
+                "stage": zero_stage,
                 "overlap_comm": True,
                 "reduce_scatter": True,
                 "contiguous_gradients": False,
@@ -38,7 +38,7 @@ def get_ds_config(
             },
             "zero_allow_untested_optimizer": True,
         }
-        config_dict.update(zero3_config_dict)
+        config_dict.update(zero_config_dict)
 
     return config_dict
 
@@ -111,7 +111,7 @@ def train_with_torch(
         loss.backward()
         optimizer.step()
         loss = postproc(step, loss) if postproc is not None else loss
-
+        
         if step % 10 == 0:
             logger.info(f"step {step} loss: {loss.item()}", ranks=0)
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -111,7 +111,7 @@ def train_with_torch(
         loss.backward()
         optimizer.step()
         loss = postproc(step, loss) if postproc is not None else loss
-        
+
         if step % 10 == 0:
             logger.info(f"step {step} loss: {loss.item()}", ranks=0)
 

--- a/examples/wideresnet/deepspeed_hf.py
+++ b/examples/wideresnet/deepspeed_hf.py
@@ -98,7 +98,7 @@ def train(args):
     if enable_pipeline:
         # FIXME: is mbs=1 correct?
         batch_size = 32 if batch_size is None else batch_size
-        ds_config_dict = get_ds_config(batch_size, 1, args.fp16, False, "Pipeline")
+        ds_config_dict = get_ds_config(batch_size, 1, args.fp16, 0, "Pipeline")
         loss_fct = ParallelCrossEntropy(group=group)
 
         def loss_fn(outputs, labels):
@@ -122,7 +122,7 @@ def train(args):
 
         logger.info(f"BS={batch_size}, MBS={micro_batch_size}", ranks=0)
         ds_config_dict = get_ds_config(
-            batch_size, micro_batch_size, args.fp16, True, "ZeRO-3"
+            batch_size, micro_batch_size, args.fp16, 3, "ZeRO-3"
         )
         model, _ = slapo.build(
             sch,

--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -20,11 +20,9 @@ def init_ds_engine(model, **kwargs):
 
     if "config" not in kwargs:
         raise ValueError("DeepSpeed config not provided.")
-    mpu = None
-    if "topology" in kwargs:
-        mpu = kwargs["topology"]
-        if isinstance(mpu, PipeModelDataParallelTopology):
-            mpu = PipelineParallelGrid(topology=mpu)
+    mpu = kwargs.get("topology", None)
+    if mpu is not None and isinstance(mpu, PipeModelDataParallelTopology):
+        mpu = PipelineParallelGrid(topology=mpu)
 
     # pylint: disable=unbalanced-tuple-unpacking
     model, optimizer, _, _ = deepspeed.initialize(

--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from ..registry import register_model_dialect
-from ...logger import get_logger, INFO
-
 from deepspeed.runtime.pipe.topology import (
     PipeModelDataParallelTopology,
     PipelineParallelGrid,
 )
+
+from ..registry import register_model_dialect
+from ...logger import get_logger, INFO
 
 logger = get_logger("DS-Engine", INFO)
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
- When TP is enabled and PP is disabled, the last linear layer is sharded. Thus, we need `ParallelCrossEntropy` as the loss instead of the loss from HF. 
- Using TP with ZeRO-1 optimizer in DS runtime requires `mpu` as input to the `deespeed.initialize(...)` function. 
- When `--disable_pipeline` is used for disabling pipeline parallelism, we need to get the `num_mp` parameters from the `args`. 

## Known issue
- With the fix, the loss converge to about 7.x after 200 steps, which is still slower than ZeRO-1 or ZeRO-3 only. 
- For now only tested with GPT model. 

## Checklist ##

- [X] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X] Code is well-documented

