### PR TITLE
[Bugfix] Using None for mpu when PP > 1

### DIFF
--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -22,7 +22,11 @@ def init_ds_engine(model, **kwargs):
         raise ValueError("DeepSpeed config not provided.")
     mpu = kwargs.get("topology", None)
     if mpu is not None and isinstance(mpu, PipeModelDataParallelTopology):
-        mpu = PipelineParallelGrid(topology=mpu)
+        if mpu.get_dim('pipe') <= 1:
+            # in the case that pipeline is disabled
+            mpu = PipelineParallelGrid(topology=mpu)
+        else:
+            mpu = None
 
     # pylint: disable=unbalanced-tuple-unpacking
     model, optimizer, _, _ = deepspeed.initialize(

--- a/slapo/model_dialect/deepspeed/engine.py
+++ b/slapo/model_dialect/deepspeed/engine.py
@@ -22,7 +22,7 @@ def init_ds_engine(model, **kwargs):
         raise ValueError("DeepSpeed config not provided.")
     mpu = kwargs.get("topology", None)
     if mpu is not None and isinstance(mpu, PipeModelDataParallelTopology):
-        if mpu.get_dim('pipe') <= 1:
+        if mpu.get_dim("pipe") <= 1:
             # in the case that pipeline is disabled
             mpu = PipelineParallelGrid(topology=mpu)
         else:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
- Check the pipeline parallel size before creating the `mpu` grid to avoid initialization error 
- Avoid creating duplicate communication groups when pipeline parallelism is used. 

## Checklist ##

- [X] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

