### PR TITLE
[Random] Random state management

### DIFF
--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -11,9 +11,10 @@ nvidia-smi -L
 echo "Running unit tests..."
 # -r: redirect the output of local rank 1 to None so that
 # only local rank 0's output is printed to the console.
-torchrun --nproc_per_node 2 -r 1:1 -m pytest tests
+# -p "no:randomly": disable randomly plugin for sharding tests.
+torchrun --nproc_per_node 2 -r 1:1 -m pytest -p "no:randomly" tests
 
 echo "Downloading test data..."
 bash benchmark/download_benchmark_dataset.sh
 echo "Running end-to-end tests..."
-python3 -m pytest -s tests/end2end.py
+python3 -m pytest -s -p "no:randomly" tests/end2end.py

--- a/examples/gpt/megatron_hf.py
+++ b/examples/gpt/megatron_hf.py
@@ -60,6 +60,10 @@ def get_model(
             delay_init=delay_init,
         )
         model, _ = slapo.build(sch, init_weights=model._init_weights)
+        # Note 1: We assume no DP and PP in this script.
+        # Note 2: This overrides Megatron random seed management, so we only use
+        #         this script for benchmarking.
+        slapo.set_random_seed(2013, None, None, sch.rank)
         report_memory()
 
     elif impl == "torchscript":

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -51,7 +51,7 @@ def schedule_model(
     # if MP group > 1.
     attn_path, out_proj_name = "h.N.attn.attention", "out_proj"
     if disable_flash_attn:
-        logger.info("Disabled Flash Attention", rank=0)
+        logger.info("Disabled Flash Attention", ranks=0)
     cnt = replace_and_shard_attention(
         sch[prefix],
         config,

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -187,7 +187,6 @@ def replace_and_shard_attention(
                 )
                 sub_sch["module"]["attn_op"].replace(new_op)
 
-
         cnt += 1
 
     return cnt

--- a/slapo/__init__.py
+++ b/slapo/__init__.py
@@ -10,3 +10,4 @@ from .tracer import *
 from .utils import *
 from .version import __version__
 from .random import set_random_seed, get_cuda_rng_tracker, is_random_seed_set
+from .checkpoint import checkpoint

--- a/slapo/__init__.py
+++ b/slapo/__init__.py
@@ -9,3 +9,4 @@ from .schedule import *
 from .tracer import *
 from .utils import *
 from .version import __version__
+from .random import set_random_seed, get_cuda_rng_tracker, is_random_seed_set

--- a/slapo/checkpoint.py
+++ b/slapo/checkpoint.py
@@ -1,0 +1,118 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modification: Megatron-LM.
+# See https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/random.py
+"""Model checkpoints and activation checkpointing with the consideration
+of 3D parallelism and random states.
+"""
+
+import torch
+from torch.utils.checkpoint import CheckpointFunction, detach_variable
+
+from .random import get_cuda_rng_tracker, is_random_seed_set, _set_cuda_rng_state
+
+
+class CheckpointFunctionWithRNGTracker(torch.autograd.Function):
+    """This function is adapted from torch.utils.checkpoint with
+    two main changes:
+        1) torch.cuda.set_rng_state is replaced with `_set_cuda_rng_state`
+        2) the states in the model parallel tracker are also properly
+            tracked/set/reset.
+    """
+
+    @staticmethod
+    def forward(ctx, run_function, *args):
+        ctx.run_function = run_function
+
+        # Copy the rng states.
+        ctx.fwd_cpu_rng_state = torch.get_rng_state()
+        ctx.fwd_cuda_rng_state = torch.cuda.get_rng_state()
+        ctx.fwd_cuda_rng_state_tracker = get_cuda_rng_tracker().get_states()
+
+        with torch.no_grad():
+            outputs = run_function(*args)
+
+        # Save non-tensor inputs in ctx, keep a placeholder None for tensors
+        # to be filled out during the backward.
+        ctx.inputs = []
+        ctx.tensor_indices = []
+        tensor_inputs = []
+        for idx, arg in enumerate(args):
+            if torch.is_tensor(arg):
+                tensor_inputs.append(arg)
+                ctx.tensor_indices.append(idx)
+                ctx.inputs.append(None)
+            else:
+                ctx.inputs.append(arg)
+
+        ctx.save_for_backward(*tensor_inputs)
+
+        return outputs
+
+    @staticmethod
+    def backward(ctx, *args):
+        if not torch.autograd._is_checkpoint_valid():
+            raise RuntimeError(
+                "Checkpointing is not compatible with .grad(), "
+                "please use .backward() if possible"
+            )
+        # Copy the list to avoid modifying original list.
+        inputs = list(ctx.inputs)
+        tensor_indices = ctx.tensor_indices
+        tensors = ctx.saved_tensors
+
+        # Fill in inputs with appropriate saved tensors.
+        for idx, tidx in enumerate(tensor_indices):
+            inputs[tidx] = tensors[idx]
+
+        # Store the current states.
+        bwd_cpu_rng_state = torch.get_rng_state()
+        bwd_cuda_rng_state = torch.cuda.get_rng_state()
+        bwd_cuda_rng_state_tracker = get_cuda_rng_tracker().get_states()
+
+        # Set the states to what it used to be before the forward pass.
+        torch.set_rng_state(ctx.fwd_cpu_rng_state)
+        _set_cuda_rng_state(ctx.fwd_cuda_rng_state)
+        get_cuda_rng_tracker().set_states(ctx.fwd_cuda_rng_state_tracker)
+
+        # Compute the forward pass.
+        detached_inputs = detach_variable(tuple(inputs))
+        with torch.enable_grad():
+            outputs = ctx.run_function(*detached_inputs)
+
+        # Set the states back to what it was at the start of this function.
+        torch.set_rng_state(bwd_cpu_rng_state)
+        _set_cuda_rng_state(bwd_cuda_rng_state)
+        get_cuda_rng_tracker().set_states(bwd_cuda_rng_state_tracker)
+
+        if isinstance(outputs, torch.Tensor):
+            outputs = (outputs,)
+
+        # run backward() with only tensor that requires grad
+        outputs_with_grad = []
+        args_with_grad = []
+        for idx in range(len(outputs)):
+            if torch.is_tensor(outputs[idx]) and outputs[idx].requires_grad:
+                outputs_with_grad.append(outputs[idx])
+                args_with_grad.append(args[idx])
+        torch.autograd.backward(outputs_with_grad, args_with_grad)
+        grads = tuple(
+            inp.grad if isinstance(inp, torch.Tensor) else None
+            for inp in detached_inputs
+        )
+        return (None,) + grads
+
+
+def checkpoint(function, *args):
+    """Checkpoint a model or part of the model. See PyTorch checkpoint
+    for details about behaviors and arguments. The only difference is
+    when the random seed is set by Slapo, the checkpoint function will
+    also track the random states and restore them properly.
+
+    TODO: The implementation in Megatron-LM has a mode to distribute
+    the saved activations across model parallel groups to further reduce
+    the memory footprint. This is not implemented here yet.
+    """
+    if not is_random_seed_set():
+        return CheckpointFunction.apply(function, *args)
+    return CheckpointFunctionWithRNGTracker.apply(function, *args)

--- a/slapo/checkpoint.py
+++ b/slapo/checkpoint.py
@@ -51,8 +51,7 @@ class CheckpointFunctionWithRNGTracker(torch.autograd.Function):
         # the tensor data. This is needed because when pipeline is enabled,
         # the tensor data may be released by the pipeline engine as it does
         # not know that the tensor is used in the backward pass.
-        tensor_inputs = detach_variable(tuple(tensor_inputs))
-        ctx.save_for_backward(*tensor_inputs)
+        ctx.save_for_backward(*detach_variable(tuple(tensor_inputs)))
 
         return outputs
 

--- a/slapo/checkpoint.py
+++ b/slapo/checkpoint.py
@@ -7,7 +7,8 @@ of 3D parallelism and random states.
 """
 
 import torch
-from torch.utils.checkpoint import CheckpointFunction, detach_variable
+from torch.utils.checkpoint import detach_variable
+from torch.utils.checkpoint import checkpoint as torch_checkpoint
 
 from .random import get_cuda_rng_tracker, is_random_seed_set, _set_cuda_rng_state
 
@@ -105,7 +106,7 @@ class CheckpointFunctionWithRNGTracker(torch.autograd.Function):
         return (None,) + grads
 
 
-def checkpoint(function, *args):
+def checkpoint(function, *args, use_reentrant=True, **kwargs):
     """Checkpoint a model or part of the model. See PyTorch checkpoint
     for details about behaviors and arguments. The only difference is
     when the random seed is set by Slapo, the checkpoint function will
@@ -116,5 +117,5 @@ def checkpoint(function, *args):
     the memory footprint. This is not implemented here yet.
     """
     if not is_random_seed_set():
-        return CheckpointFunction.apply(function, *args)
+        return torch_checkpoint(function, *args, use_reentrant, **kwargs)
     return CheckpointFunctionWithRNGTracker.apply(function, *args)

--- a/slapo/checkpoint.py
+++ b/slapo/checkpoint.py
@@ -20,6 +20,8 @@ class CheckpointFunctionWithRNGTracker(torch.autograd.Function):
             tracked/set/reset.
     """
 
+    # pylint: disable=abstract-method, arguments-differ
+
     @staticmethod
     def forward(ctx, run_function, *args):
         ctx.run_function = run_function
@@ -91,9 +93,9 @@ class CheckpointFunctionWithRNGTracker(torch.autograd.Function):
         # run backward() with only tensor that requires grad
         outputs_with_grad = []
         args_with_grad = []
-        for idx in range(len(outputs)):
-            if torch.is_tensor(outputs[idx]) and outputs[idx].requires_grad:
-                outputs_with_grad.append(outputs[idx])
+        for idx, output in enumerate(outputs):
+            if torch.is_tensor(output) and output.requires_grad:
+                outputs_with_grad.append(output)
                 args_with_grad.append(args[idx])
         torch.autograd.backward(outputs_with_grad, args_with_grad)
         grads = tuple(

--- a/slapo/checkpoint.py
+++ b/slapo/checkpoint.py
@@ -117,5 +117,5 @@ def checkpoint(function, *args, use_reentrant=True, **kwargs):
     the memory footprint. This is not implemented here yet.
     """
     if not is_random_seed_set():
-        return torch_checkpoint(function, *args, use_reentrant, **kwargs)
+        return torch_checkpoint(function, *args, use_reentrant=use_reentrant, **kwargs)
     return CheckpointFunctionWithRNGTracker.apply(function, *args)

--- a/slapo/op/__init__.py
+++ b/slapo/op/__init__.py
@@ -1,3 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Custom Ops."""
+from .cross_entropy import ParallelCrossEntropy
+from .dropout import DropoutWithTensorParallel

--- a/slapo/op/dropout.py
+++ b/slapo/op/dropout.py
@@ -17,6 +17,8 @@ class DropoutWithTensorParallel(nn.Dropout):
     the convergence.
     """
 
+    # pylint: disable=redefined-builtin
+
     def forward(self, input):
         with get_cuda_rng_tracker().fork():
             return super().forward(input)

--- a/slapo/op/dropout.py
+++ b/slapo/op/dropout.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Dropout module."""
+
+from torch import nn
+
+from ..random import get_cuda_rng_tracker
+
+
+class DropoutWithTensorParallel(nn.Dropout):
+    """The dropout that supposed to be used in parallel region.
+    In parallel region means the original input tensor is partitioned
+    due to tensor parallelism or sequence parallelism. In this case,
+    we need to make sure the dropout on each device in the same
+    tensor parallel group has DIFFERENT random seed; otherwise each
+    partitioned tensor will have the same dropout mask, which may hurt
+    the convergence.
+    """
+
+    def forward(self, input):
+        with get_cuda_rng_tracker().fork():
+            return super().forward(input)

--- a/slapo/random.py
+++ b/slapo/random.py
@@ -116,7 +116,7 @@ def get_cuda_rng_tracker():
     return _CUDA_RNG_STATE_TRACKER
 
 
-def model_parallel_cuda_manual_seed(seed):
+def model_parallel_cuda_manual_seed(seed, tp_rank):
     """Initialize model parallel cuda seed.
     This function should be called after the model parallel is
     initialized. Also, no torch.cuda.manual_seed should be called
@@ -134,7 +134,7 @@ def model_parallel_cuda_manual_seed(seed):
     """
     # 2718 is just for fun and any POSITIVE value will work.
     offset = seed + 2718
-    tensor_model_parallel_seed = offset + get_tensor_model_parallel_rank()
+    tensor_model_parallel_seed = offset + tp_rank
     # Data parallel gets the original seed.
     data_parallel_seed = seed
 

--- a/slapo/random.py
+++ b/slapo/random.py
@@ -9,7 +9,6 @@ import random
 
 import numpy as np
 import torch
-from torch import distributed as dist
 from torch.cuda import _lazy_call
 
 # Default name for the model parallel rng tracker.

--- a/slapo/random.py
+++ b/slapo/random.py
@@ -1,0 +1,147 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modification: Megatron-LM.
+# See https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/random.py
+
+import contextlib
+
+import torch
+from torch.cuda import _lazy_call
+
+# Default name for the model parallel rng tracker.
+_MODEL_PARALLEL_RNG_TRACKER_NAME = "model-parallel-rng"
+
+
+def _set_cuda_rng_state(new_state, device=-1):
+    """Sets the random number generator state of the current GPU.
+    Argumentss:
+        new_state (torch.ByteTensor): The desired state
+    This function is adapted from PyTorch repo (torch.cuda.set_rng_state)
+    with a single change: the input state is not cloned. Cloning caused
+    major performance issues for +4 GPU cases.
+    """
+    if device == -1:
+        device = torch.device("cuda")
+    elif isinstance(device, str):
+        device = torch.device(device)
+    elif isinstance(device, int):
+        device = torch.device("cuda", device)
+
+    def cb():
+        idx = device.index
+        if idx is None:
+            idx = torch.cuda.current_device()
+        default_generator = torch.cuda.default_generators[idx]
+        default_generator.set_state(new_state)
+
+    _lazy_call(cb)
+
+
+class CudaRNGStatesTracker:
+    """Tracker for the cuda RNG states.
+    Using the `add` method, a cuda rng state is initialized based on
+    the input `seed` and is assigned to `name`. Later, by forking the
+    rng state, we can perform operations and return to our starting
+    cuda state.
+    """
+
+    def __init__(self):
+        # Map from a string name to the cuda rng state.
+        self.states_ = {}
+        # Seeds are just for book keeping and ensure no seed is set twice.
+        self.seeds_ = set()
+
+    def reset(self):
+        """Set to the initial state (no tracker)."""
+        self.states_ = {}
+        self.seeds_ = set()
+
+    def get_states(self):
+        """Get rng states. Copy the dictionary so we have direct
+        pointers to the states, not just a pointer to the dictionary."""
+        states = {}
+        for name in self.states_:
+            states[name] = self.states_[name]
+        return states
+
+    def set_states(self, states):
+        """Set the rng states. For efficiency purposes, we do not check
+        the size of seed for compatibility."""
+        self.states_ = states
+
+    def add(self, name, seed):
+        """Track the rng state."""
+        # Check seed is not already used.
+        if seed in self.seeds_:
+            raise Exception("seed {} already exists".format(seed))
+        self.seeds_.add(seed)
+        # Check that state is not already defined.
+        if name in self.states_:
+            raise Exception("cuda rng state {} already exists".format(name))
+        # Get the current rng state.
+        orig_rng_state = torch.cuda.get_rng_state()
+        # Set the new state and store it.
+        torch.cuda.manual_seed(seed)
+        self.states_[name] = torch.cuda.get_rng_state()
+        # Reset rng state to what it was.
+        _set_cuda_rng_state(orig_rng_state)
+
+    @contextlib.contextmanager
+    def fork(self, name=_MODEL_PARALLEL_RNG_TRACKER_NAME):
+        """Fork the cuda rng state, perform operations, and exit with
+        the original state."""
+        # Check if we have added the state
+        if name not in self.states_:
+            raise Exception("cuda rng state {} is not added".format(name))
+        # Store current rng state.
+        orig_cuda_rng_state = torch.cuda.get_rng_state()
+        # Set rng state to the desired one
+        _set_cuda_rng_state(self.states_[name])
+        # Do the stuff we wanted to do.
+        try:
+            yield
+        finally:
+            # Update the current rng state for later use.
+            self.states_[name] = torch.cuda.get_rng_state()
+            # And set the state to the original state we started with.
+            _set_cuda_rng_state(orig_cuda_rng_state)
+
+
+# RNG tracker object.
+_CUDA_RNG_STATE_TRACKER = CudaRNGStatesTracker()
+
+
+def get_cuda_rng_tracker():
+    """Get cuda rng tracker."""
+    return _CUDA_RNG_STATE_TRACKER
+
+
+def model_parallel_cuda_manual_seed(seed):
+    """Initialize model parallel cuda seed.
+    This function should be called after the model parallel is
+    initialized. Also, no torch.cuda.manual_seed should be called
+    after this function. Basically, this is replacement for that
+    function.
+    Two set of RNG states are tracked:
+        default state: This is for data parallelism and is the same among a
+                       set of model parallel GPUs but different across
+                       different model paralle groups. This is used for
+                       example for dropout in the non-tensor-model-parallel regions.
+        tensor-model-parallel state: This state is different among a set of model
+                              parallel GPUs, but the same across data parallel
+                              groups. This is used for example for dropout in
+                              model parallel regions.
+    """
+    # 2718 is just for fun and any POSITIVE value will work.
+    offset = seed + 2718
+    tensor_model_parallel_seed = offset + get_tensor_model_parallel_rank()
+    # Data parallel gets the original seed.
+    data_parallel_seed = seed
+
+    _CUDA_RNG_STATE_TRACKER.reset()
+    # Set the default state.
+    torch.cuda.manual_seed(data_parallel_seed)
+    # and model parallel state.
+    _CUDA_RNG_STATE_TRACKER.add(
+        _MODEL_PARALLEL_RNG_TRACKER_NAME, tensor_model_parallel_seed
+    )

--- a/slapo/random.py
+++ b/slapo/random.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Modification: Megatron-LM.
 # See https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/random.py
+"""Random seed and states management."""
 
 import contextlib
 import random

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -16,11 +16,11 @@ from typing import Any, Optional, Union
 import torch
 import torch.distributed as dist
 from torch import fx, nn
-from torch.utils import checkpoint
 
 # pylint: disable=unused-import
 import torch.nn.functional as F
 
+from .checkpoint import checkpoint as checkpoint_module
 from .logger import get_logger
 from .model_dialect import get_dialect_cls
 from .pipeline import (
@@ -987,7 +987,7 @@ class SubgraphWrapper(nn.Module):
                     ordered_args = order_args_fn(*args, **kwargs)
 
                 # Note: checkpoint cannot accept kwargs
-                return checkpoint.checkpoint(self.mod, *ordered_args)
+                return checkpoint_module(self.mod, *ordered_args)
 
         self.replace(CheckPointWrapper(self.mod))
 

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -42,6 +42,7 @@ from .op.linear import LinearWithSeparateBias
 from .utils.common import transfer_hooks, is_lambda_function
 from .utils.mapping import MAPPING_FROM_FUNCTIONAL_TO_MODULE
 from .pattern import Pattern, ModulePattern, call_module
+from .random import model_parallel_cuda_manual_seed
 
 logger = get_logger()
 
@@ -1326,6 +1327,25 @@ def init_target_engine(sch, target, **kwargs):
     )
 
 
+def _set_random_seed(sch, seed_, data_parallel_random_init=False):
+    """Set random seed for reproducability.
+    https://github.com/NVIDIA/Megatron-LM/blob/8ce8256ff09373a275245aff3db68a3688218c44/megatron/initialize.py#L205
+    """
+    if seed_ is not None and seed_ > 0:
+        # Ensure that different pipeline MP stages get different seeds.
+        seed = seed_ + (100 * dist.get_rank())
+        # Ensure different data parallel ranks get different seeds
+        if data_parallel_random_init:
+            seed = seed + (10 * dist.get_rank())
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.device_count() > 0:
+            model_parallel_cuda_manual_seed(seed, sch.rank)
+    else:
+        raise ValueError("Seed ({}) should be a positive integer.".format(seed))
+
+
 def build(
     sch: Schedule,
     target=None,
@@ -1354,5 +1374,9 @@ def build(
         )
     else:
         model = sch.mod
+
+    if dist.get_rank() > 0:
+        # just a random prime number
+        _set_random_seed(7919, sch)
 
     return init_target_engine(model, target, **kwargs)

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -4,6 +4,7 @@
 Test checkpoints. Note that this test has to be invoked by torchrun.
 See ci/task_unit_tests.sh for an example.
 """
+# pylint: disable=unused-argument
 
 import os
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Test checkpoints. Note that this test has to be invoked by torchrun.
+See ci/task_unit_tests.sh for an example.
+"""
+
+import os
+
+import pytest
+import torch
+from torch import distributed as dist
+from torch.autograd import Variable
+
+from slapo import checkpoint, get_cuda_rng_tracker, set_random_seed
+from slapo.sharding import reduce_backward_grad, reduce_forward_output
+
+
+def test_activation_checkpoint_with_rng_states(init_dist):
+    world_size = dist.get_world_size()
+    full_size = 5 * world_size
+
+    tp_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(tp_rank)
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = torch.nn.Linear(full_size, 5, bias=False)
+            self.dropout1 = torch.nn.Dropout(0.5)
+            self.linear2 = torch.nn.Linear(5, full_size, bias=False)
+            self.dropout2 = torch.nn.Dropout(0.5)
+
+        def orig_forward(self, x):
+            x = reduce_backward_grad(x, None)
+            x = self.linear1(x)
+            # The output of lienar1 is partitioned, so we use different seeds.
+            with get_cuda_rng_tracker().fork():
+                x = self.dropout1(x)
+            x = self.linear2(x)
+            # The output of linear2 is partial sum, so we use the same seed.
+            x = self.dropout2(x)
+            x = reduce_forward_output(x, None)
+            return x
+
+        def forward(self, x, enable_checkpoint):
+            if enable_checkpoint:
+                return checkpoint(self.orig_forward, x)
+            return self.orig_forward(x)
+
+    data = torch.randn((full_size, full_size), requires_grad=True).cuda(tp_rank)
+    dist.broadcast(data, src=0)
+    data = Variable(data, requires_grad=True)
+
+    model = Model().cuda(tp_rank)
+
+    def run(model, data, enable_checkpoint):
+        # 1. Run the model forward and backward.
+        out = model(data, enable_checkpoint)
+        out.mean().backward()
+        # 2. Retrieve gradients.
+        linear1_weight_grad = model.linear1.weight.grad.clone()
+        linear2_weight_grad = model.linear2.weight.grad.clone()
+        input_grad = data.grad.clone()
+        # 3. Clear gradients.
+        model.linear1.weight.grad = None
+        model.linear2.weight.grad = None
+        data.grad = None
+        return out, linear1_weight_grad, linear2_weight_grad, input_grad
+
+    # Run the model without activation checkpointing for reference.
+    set_random_seed(123, None, None, tp_rank)
+    refs = run(model, data, False)
+    # Run the model with activation checkpointing.
+    set_random_seed(123, None, None, tp_rank)
+    outs = run(model, data, True)
+
+    for ref, out in zip(refs, outs):
+        torch.testing.assert_close(out, ref)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test custom ops. Note that this test has to be invoked by torchrun since
+most custom ops are for tensor parallelism.
+"""
+import os
+import pytest
+
+import torch
+from torch import nn
+from torch import distributed as dist
+
+from slapo import op
+from slapo.random import set_random_seed
+
+
+def test_dropout(init_dist):
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+
+    data = torch.rand(10, 10).cuda(local_rank)
+    dist.broadcast(data, src=0)
+
+    # The custom dropout should throw error if set_random_seed is not called.
+    with pytest.raises(Exception):
+        op.DropoutWithTensorParallel(p=0.5)(data)
+
+    set_random_seed(123, tp_rank=local_rank)
+
+    # Assuming all devices are in the same TP group, the native dropout
+    # should produce the same output on all devices.
+    out = nn.Dropout(p=0.5)(data)
+    out_reduced = out.clone()
+    dist.all_reduce(out_reduced)
+    torch.testing.assert_close(
+        out * world_size,
+        out_reduced,
+        msg=lambda msg: f"output mismatch\n{msg}",
+    )
+
+    # The custom dropout should produce different outputs on different devices
+    # even they are in the same TP group.
+    out = op.DropoutWithTensorParallel(p=0.5)(data)
+    out_reduced = out.clone()
+    dist.all_reduce(out_reduced)
+    with pytest.raises(Exception):
+        torch.testing.assert_close(out * world_size, out_reduced)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -13,7 +13,7 @@ from torch import nn
 from torch import distributed as dist
 
 from slapo import op
-from slapo.random import set_random_seed
+from slapo.random import set_random_seed, get_cuda_rng_tracker
 
 
 def test_dropout(init_dist):
@@ -23,6 +23,8 @@ def test_dropout(init_dist):
 
     data = torch.rand(10, 10).cuda(local_rank)
     dist.broadcast(data, src=0)
+
+    get_cuda_rng_tracker().reset()
 
     # The custom dropout should throw error if set_random_seed is not called.
     with pytest.raises(Exception):

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
 """
 Test custom ops. Note that this test has to be invoked by torchrun since
 most custom ops are for tensor parallelism.
 """
+# pylint: disable=unused-argument
 import os
 import pytest
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Modification: Megatron-LM.
 # See https://github.com/NVIDIA/Megatron-LM/blob/main/tests/tensor_parallel/test_random.py
+"""
+Test random state managements. Note that this test has to be invoked by torchrun.
+See ci/task_unit_tests.sh for an example.
+"""
+
 import os
 
 import pytest

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -26,7 +26,7 @@ def test_cuda_rng_states_tracker():
     assert rng_tracker.get_states()["state1"] == 1234
 
     rng_tracker.reset()
-    assert rng_tracker.get_states() == {}
+    assert not rng_tracker.get_states()
 
     seed = 1111
     rng_tracker.add("state2", seed)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modification: Megatron-LM.
+# See https://github.com/NVIDIA/Megatron-LM/blob/main/tests/tensor_parallel/test_random.py
+import os
+
+import pytest
+import torch
+
+from slapo.random import (
+    _CUDA_RNG_STATE_TRACKER,
+    CudaRNGStatesTracker,
+    get_cuda_rng_tracker,
+    model_parallel_cuda_manual_seed,
+)
+
+
+def test_cuda_rng_states_tracker():
+    rng_tracker = CudaRNGStatesTracker()
+    rng_tracker.set_states({"state1": 1234})
+    assert rng_tracker.get_states()["state1"] == 1234
+
+    rng_tracker.reset()
+    assert rng_tracker.get_states() == {}
+
+    seed = 1111
+    rng_tracker.add("state2", seed)
+    with pytest.raises(Exception):
+        assert rng_tracker.add("state3", seed)
+
+    with pytest.raises(Exception):
+        assert rng_tracker.add("state2", 111)
+
+    assert rng_tracker.get_states()["state2"] is not None
+    with pytest.raises(Exception):
+        assert ()
+
+    rng_tracker.fork("state2")
+    torch.cuda.manual_seed(seed)
+    rng_state = torch.cuda.get_rng_state()
+    assert torch.equal(rng_tracker.get_states()["state2"], rng_state)
+
+
+def test_model_parallel_seed():
+    assert torch.cuda.initial_seed() != 123
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    tp_seed = model_parallel_cuda_manual_seed(123, tp_rank=local_rank)
+    assert _CUDA_RNG_STATE_TRACKER.get_states()["model-parallel-rng"] is not None
+
+    # Outside the context, the seed should be the same.
+    assert torch.cuda.initial_seed() == 123
+
+    # Inside the context, the seed should be different.
+    with get_cuda_rng_tracker().fork():
+        assert torch.cuda.initial_seed() == tp_seed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Test sharding primitive. Note that this test has to be invoked by torchrun. For example:
-torchrun --nproc_per_node 2 -m pytest test_shard.py
+Test sharding primitive. Note that this test has to be invoked by torchrun.
+See ci/task_unit_tests.sh for an example.
 """
 # pylint: disable=unused-argument
 import os

--- a/tests/test_shard_sync_op.py
+++ b/tests/test_shard_sync_op.py
@@ -20,9 +20,6 @@ from slapo.sharding import sync_ops
 
 def init_model_and_data(local_rank):
     model = nn.Linear(10, 10).cuda(local_rank)
-    # Make sure all devices have the same model.
-    dist.broadcast(model.weight.data, src=0)
-    dist.broadcast(model.bias.data, src=0)
     ref_model = copy.deepcopy(model)
 
     data = torch.randn((10, 10), requires_grad=True).cuda(local_rank)

--- a/tests/test_shard_sync_op.py
+++ b/tests/test_shard_sync_op.py
@@ -3,7 +3,7 @@
 
 """
 Test sync ops for sharding. Note that this test has to be invoked by torchrun.
-For example: torchrun --nproc_per_node 2 -m pytest test_shard_sync_op.py
+See ci/task_unit_tests.sh for an example.
 """
 # pylint: disable=unused-argument
 import copy


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
- Add random state management to deal with the requirements of using the same or different random seeds in a TP group. The implementation is based on the one in Megatron-LM.
- Add an activation checkpointing with the consideration of random states.
- Add an op `DropoutWithTensorParallel` that can be replaced by users when writing a schedule.
- Add unit tests.
- Disable randomly plugin in pytest. This plugin makes our random seed setup in the test fixture useless.

Notes:
1. We now offer an API `set_random_seed` for users to call in the training script. Users have to manually call it and specify the rank of 3D parallelism.
2. All changes in this PR will have no impact if `set_random_seed` is not called in advance.
3. Fidelity testing shows the updated GPT schedule with 3D parallelism could align the loss to ZeRO-3 (with and without activation checkpointing), but flash attention has to be disabled.
4. I'll update the flash attention to the latest one and see if the problem will gone.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac @chhzh123 