### PR TITLE
[GPT] Use flash-attention and enable dropout

### DIFF
--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -19,7 +19,7 @@ bash benchmark/download_benchmark_dataset.sh
 
 # Remove this path when xFormers fixes this issue.
 echo "Applying xFormers path..."
-XFORMER_PATH=`python3 -c "import xformers; print(xformers.__path__[0])"`/..
+XFORMER_PATH=`python3 -c "import xformers, pathlib; print(pathlib.Path(xformers.__path__[0]).parent)"`
 cp scripts/xformers_patch $XFORMER_PATH
 pushd $XFORMER_PATH
 git config --global --add safe.directory $XFORMER_PATH

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -19,7 +19,7 @@ bash benchmark/download_benchmark_dataset.sh
 
 # Remove this path when xFormers fixes this issue.
 echo "Applying xFormers path..."
-XFORMER_PATH=`python3 -c "import xformers; print(xformers.__path__[0])"`
+XFORMER_PATH=`python3 -c "import xformers; print(xformers.__path__[0])"`/..
 cp scripts/xformers_patch $XFORMER_PATH
 pushd $XFORMER_PATH
 git config --global --add safe.directory $XFORMER_PATH

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -16,5 +16,16 @@ torchrun --nproc_per_node 2 -r 1:1 -m pytest -p "no:randomly" tests
 
 echo "Downloading test data..."
 bash benchmark/download_benchmark_dataset.sh
+
+# Remove this path when xFormers fixes this issue.
+echo "Applying xFormers path..."
+XFORMER_PATH=`python3 -c "import xformers; print(xformers.__path__[0])"`
+cp scripts/xformers_patch $XFORMER_PATH
+pushd $XFORMER_PATH
+git reset --hard
+git apply xformers_patch
+git --no-pager diff
+popd
+
 echo "Running end-to-end tests..."
 python3 -m pytest -s -p "no:randomly" tests/end2end.py

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -22,6 +22,7 @@ echo "Applying xFormers path..."
 XFORMER_PATH=`python3 -c "import xformers; print(xformers.__path__[0])"`
 cp scripts/xformers_patch $XFORMER_PATH
 pushd $XFORMER_PATH
+git config --global --add safe.directory $XFORMER_PATH
 git reset --hard
 git apply xformers_patch
 git --no-pager diff

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -264,17 +264,23 @@ RUN cd $HOME/Megatron-LM && git checkout 0bb597b
 ENV PYTHONPATH "${PYTHONPATH}:$HOME/Megatron-LM"
 
 # Install xformers
-RUN git clone https://github.com/jfc4050/xformers $HOME/xformers && \
-    cd $HOME/xformers && git checkout -b bias-dropout origin/bias-dropout && \
-    git checkout 500b8d4 && git submodule sync && git submodule update --init --recursive
+RUN git clone https://github.com/facebookresearch/xformers.git $HOME/xformers && \
+    cd $HOME/xformers && git checkout 48a77cc && \
+    git submodule sync && git submodule update --init --recursive
 RUN cd $HOME/xformers && \
     export FORCE_CUDA="1" && \
     export TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0" && \
     CUDA_VISIBLE_DEVICES=0 pip3 install -e ".[dev]"
 
+# Install flash_attn
+RUN git clone https://github.com/jfc4050/flash-attention.git $HOME/flash-attention && \
+    cd $HOME/flash-attention/ && git checkout f528682
+RUN cd $HOME/flash-attention/ && \
+    pip3 install -e ".[dev]"
+
 # Install epoi
 RUN git clone https://github.com/comaniac/epoi --recursive $HOME/epoi
-RUN cd $HOME/epoi && git fetch && git checkout b2e2e98 && pip3 install -e ".[dev]"
+RUN cd $HOME/epoi && git fetch && git checkout b26032e && pip3 install -e ".[dev]"
 
 # Install transformers
 RUN git clone https://github.com/huggingface/transformers.git $HOME/transformers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -280,7 +280,7 @@ RUN cd $HOME/flash-attention/ && \
 
 # Install epoi
 RUN git clone https://github.com/comaniac/epoi --recursive $HOME/epoi
-RUN cd $HOME/epoi && git fetch && git checkout b26032e && pip3 install -e ".[dev]"
+RUN cd $HOME/epoi && git fetch && git checkout fa90fa7 && pip3 install -e ".[dev]"
 
 # Install transformers
 RUN git clone https://github.com/huggingface/transformers.git $HOME/transformers

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,12 +16,19 @@ export PYTHONPATH=`pwd`:$PYTHONPATH
 
 - xformers:
 ```
-git clone https://github.com/jfc4050/xformers
+git clone https://github.com/facebookresearch/xformers.git
 cd xformers
-git checkout -b attn-bias-pr-2 origin/attn-bias-pr-2
-git checkout 500b8d4
+git checkout 48a77cc
 git submodule sync 
 git submodule update --init --recursive
+pip3 install -e ".[dev]"
+```
+
+- flash-attention:
+```
+git clone https://github.com/jfc4050/flash-attention.git
+cd flash-attention
+git checkout f528682
 pip3 install -e ".[dev]"
 ```
 
@@ -29,7 +36,7 @@ pip3 install -e ".[dev]"
 ```
 git clone https://github.com/comaniac/epoi --recursive
 cd epoi
-git checkout b2e2e98
+git checkout b26032e
 pip3 install -e ".[dev]"
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ pip3 install -e ".[dev]"
 ```
 git clone https://github.com/comaniac/epoi --recursive
 cd epoi
-git checkout b26032e
+git checkout fa90fa7
 pip3 install -e ".[dev]"
 ```
 

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -43,6 +43,13 @@ def reconfig_model(args, model_config):
         model_config.attention_types = [[["global"], model_config.num_layers]]
         model_config.attention_layers = ["global"] * model_config.num_layers
 
+    if args.dropout > 0:
+        model_config.attention_dropout = args.dropout
+        model_config.resid_dropout = args.dropout
+        model_config.embed_dropout = args.dropout
+
+    model_config.max_position_embeddings = args.seq_len
+
     return model_config
 
 
@@ -201,7 +208,11 @@ def train(args):
     # for now always use seq_length 1024
     # TODO: make the dataloader generic to different sequence length
     train_loader, _ = get_dataloader(
-        args.model_name, micro_batch_size, enable_pipeline, mpu=model.mpu
+        args.model_name,
+        micro_batch_size,
+        enable_pipeline,
+        mpu=model.mpu,
+        max_seq_length=args.seq_len,
     )
 
     loader = RepeatingLoader(train_loader)
@@ -281,6 +292,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--num-attn-heads", type=int, default=-1, help="Number of attention heads"
+    )
+    parser.add_argument(
+        "--dropout", type=float, default=0.0, help="Dropout probability"
     )
     parser.add_argument(
         "--pmp", type=int, default=2, help="Pipeline model parallel size"

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -9,13 +9,9 @@ from slapo.logger import get_logger
 from schedule import (
     broadcast_input,
     checkpoint,
-    remove_cast,
     replace_and_shard_mlp,
     replace_and_shard_attention,
-    replace_qkv,
-    shard_qkv,
     shard_word_embedding,
-    trace_attention,
 )
 
 logger = get_logger("GPT")

--- a/examples/opt/schedule.py
+++ b/examples/opt/schedule.py
@@ -29,26 +29,20 @@ def trace_attention(sch, config, attn_path="h.N.attn.attention"):
 
 
 def fix_attention_mask_shape(sch):
-    # EPOI attention module uses repeat to process attention mask to
-    # align xformer attention mask shape:
-    # (B, 1, Tgt_S, Src_S)
-    # (B, 1, 1, S) -repeat->  (B, H, S, S) -reshape-> (B x H, S, S),
-    # so we need to replace "repeat" wit the sharded H.
+    # Attention mask may needed to be expanded from (B, 1, 1, S)
+    # to (B, H, S, S), where H is sharded.
     ops = sch.find_node(
-        lambda node: node.op == "call_method"
-        and node.target == "repeat"
-        and len(node.args) == 5  # args[0] is self
-        and node.args[1] == 1
-        and node.args[-1] == 1
+        lambda node: node.op == "call_method" and node.target == "expand"
     )
 
-    def new_repeat(tensor, *old_args):
-        assert len(old_args) == 4
-        new_args = (old_args[0],) + (old_args[1] // sch.world_size, 1, 1)
-        return tensor.repeat(*new_args)
+    def new_expand(tensor, *args):
+        # (B, 1, 1, S) -> (B, H, S, S)
+        assert len(args) == 4
+        out = tensor.expand(args[0], args[1] // sch.world_size, *args[2:])
+        return out.contiguous()
 
     for op in ops:
-        sch.replace(new_repeat, op[1])
+        sch.replace(new_expand, op[1])
 
 
 def replace_and_shard_attention(
@@ -110,7 +104,6 @@ def replace_and_shard_attention(
                 "use_cache": False,
             },
         )
-        fix_attention_mask_shape(sub_sch["module"])
 
         def pattern(x: torch.Tensor) -> torch.Tensor:
             x = call_module("query|key|value", x)
@@ -126,6 +119,7 @@ def replace_and_shard_attention(
         if sch.world_size > 1:
             sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)
             sub_sch["module.FusedQKV_0.fused_linear"].shard("bias", axis=0)
+            fix_attention_mask_shape(sub_sch["module"])
             sub_sch["module.FusedQKV_0.fused_linear"].sync(
                 mode="bwd_post", sync_op_or_fn="all_reduce"
             )

--- a/scripts/xformers_patch
+++ b/scripts/xformers_patch
@@ -1,0 +1,13 @@
+diff --git a/xformers/ops/fmha/cutlass.py b/xformers/ops/fmha/cutlass.py
+index d5181ac..c6fcb5b 100644
+--- a/xformers/ops/fmha/cutlass.py
++++ b/xformers/ops/fmha/cutlass.py
+@@ -184,7 +184,7 @@ class BwOp(AttentionBwOpBase):
+         torch.Tensor,
+         LowerTriangularMask,
+         # TODO: Fix handling of gradient through the fMHA autograd function
+-        # LowerTriangularMaskWithTensorBias,
++        LowerTriangularMaskWithTensorBias,
+     }
+     SUPPORTS_ATTN_BIAS_GRAD = True
+     SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

**To existing developers:** please update your environments by referring to examples/README.md or Dockerfile. 

## Description ##

This PR updates `epoi` used in GPT schedule to the latest version, which uses flash-attention triton kernel for better performance and attention dropout supports. The GPT schedule is also updated to support different random seeds within a TP group for attention dropout. With this PR, Slapo 3D could align the loss value of ZeRO-3 even with dropout enabled.

1. **Update GPT schedule dependency.** `epoi`, `xformers` are updated to the latest compatible commits. Introduce `flash_attention` as the new dependency of GPT scheduling.
2. The latest `xformers` doesn't allow CUTLASS kernel to take bias. We use a patch to fix it temporary.
3. **Dockerfile.** The docker file is updated. The CI docker image has been updated to v0.02.
4. **Data loader.** Use gpt-neo tokenizer which has maximum token length 2048.
5. **Data loader.** Support configurable sequence length.
6. **GPT.** Support configurable dropout probabilities and maximum sequence length.
7. **GPT.** When the GPU we are running is sm_80 (e.g., A100), use triton flash attention kernel.
8. **GPT.** Use different random seeds for attention dropout.
9. **Utility.** A simple utility to calculate the TFLOPS of decoder model. It can be used like this

```
# samples/sec, ngpu, seq_len, nlayers, hs, vocab_size
python3 -c "from slapo.utils.report import calc_decoder_tflops; print(calc_decoder_tflops(35, 8, 2048, 24, 2048, 50528))"
```

With all above changes, we could use the following command to run GPT with 3D (DP, PP, TP)=(2, 2, 2):

```
deepspeed ./examples/gpt/deepspeed_hf.py --pmp 2 --tmp 2 \
--batch_size 128 --micro_batch_size 4 --model_name EleutherAI/gpt-neo-2.7B \
--iter_nums 170 --hidden-size 2048 --nlayers 24 --num-attn-heads 16 \
--dropout 0.1 --seq_len 1024
```

And here is another example:

```
deepspeed ./examples/gpt/deepspeed_hf.py --pmp 2 --tmp 2 \
--batch_size 32 --micro_batch_size 4 --model_name EleutherAI/gpt-neo-2.7B \
--iter_nums 170 --hidden-size 2048 --nlayers 24 --num-attn-heads 16 \
--dropout 0.1 --seq_len 2048
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac 