### PR TITLE
[Op] Add attention and bias_gelu ops

### DIFF
--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -8,6 +8,17 @@ set -o pipefail
 
 nvidia-smi -L
 
+# Remove this path when xFormers fixes this issue.
+echo "Applying xFormers path..."
+XFORMER_PATH=`python3 -c "import xformers, pathlib; print(pathlib.Path(xformers.__path__[0]).parent)"`
+cp scripts/xformers_patch $XFORMER_PATH
+pushd $XFORMER_PATH
+git config --global --add safe.directory $XFORMER_PATH
+git reset --hard
+git apply xformers_patch
+git --no-pager diff
+popd
+
 echo "Running unit tests..."
 # torchrun:
 #   -r: redirect the output of local rank 1 to None so that
@@ -19,17 +30,6 @@ torchrun --nproc_per_node 2 -r 1:1 -m pytest -rxXs -p "no:randomly" tests
 
 echo "Downloading test data..."
 bash benchmark/download_benchmark_dataset.sh
-
-# Remove this path when xFormers fixes this issue.
-echo "Applying xFormers path..."
-XFORMER_PATH=`python3 -c "import xformers, pathlib; print(pathlib.Path(xformers.__path__[0]).parent)"`
-cp scripts/xformers_patch $XFORMER_PATH
-pushd $XFORMER_PATH
-git config --global --add safe.directory $XFORMER_PATH
-git reset --hard
-git apply xformers_patch
-git --no-pager diff
-popd
 
 echo "Running end-to-end tests..."
 python3 -m pytest -s -p "no:randomly" tests/end2end.py

--- a/ci/task_unit_test.sh
+++ b/ci/task_unit_test.sh
@@ -9,10 +9,13 @@ set -o pipefail
 nvidia-smi -L
 
 echo "Running unit tests..."
-# -r: redirect the output of local rank 1 to None so that
-# only local rank 0's output is printed to the console.
-# -p "no:randomly": disable randomly plugin for sharding tests.
-torchrun --nproc_per_node 2 -r 1:1 -m pytest -p "no:randomly" tests
+# torchrun:
+#   -r: redirect the output of local rank 1 to None so that
+#       only local rank 0's output is printed to the console.
+# pytest:
+#   -rxXs: show extra info for each test, including xfailed, xpassed, and skipped.
+#   -p "no:randomly": disable randomly plugin for sharding tests.
+torchrun --nproc_per_node 2 -r 1:1 -m pytest -rxXs -p "no:randomly" tests
 
 echo "Downloading test data..."
 bash benchmark/download_benchmark_dataset.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -274,7 +274,7 @@ RUN cd $HOME/xformers && \
 
 # Install flash_attn
 RUN git clone https://github.com/jfc4050/flash-attention.git $HOME/flash-attention && \
-    cd $HOME/flash-attention/ && git checkout f528682
+    cd $HOME/flash-attention/ && git checkout 528c70e
 RUN cd $HOME/flash-attention/ && \
     pip3 install -e ".[dev]"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -274,7 +274,7 @@ RUN cd $HOME/xformers && \
 
 # Install flash_attn
 RUN git clone https://github.com/jfc4050/flash-attention.git $HOME/flash-attention && \
-    cd $HOME/flash-attention/ && git checkout 528c70e
+    cd $HOME/flash-attention/ && git checkout 3676bd2
 RUN cd $HOME/flash-attention/ && \
     pip3 install -e ".[dev]"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,7 +28,7 @@ pip3 install -e ".[dev]"
 ```
 git clone https://github.com/jfc4050/flash-attention.git
 cd flash-attention
-git checkout 528c70e
+git checkout 3676bd2
 pip3 install -e ".[dev]"
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,7 +28,7 @@ pip3 install -e ".[dev]"
 ```
 git clone https://github.com/jfc4050/flash-attention.git
 cd flash-attention
-git checkout f528682
+git checkout 528c70e
 pip3 install -e ".[dev]"
 ```
 

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -48,14 +48,14 @@ def schedule_model(
     attn_path, out_proj_name = "h.N.attn.attention", "out_proj"
     if disable_flash_attn:
         logger.info("Disabled Flash Attention", ranks=0)
-    cnt = replace_and_shard_attention(
+    cnt, attn_op_name = replace_and_shard_attention(
         sch[prefix],
         config,
         delay_init=delay_init,
         disable_flash_attn=disable_flash_attn,
         sequence_parallel=sequence_parallel,
     )
-    logger.info(f"Replace {cnt} attention patterns", ranks=0)
+    logger.info(f"Replace {cnt} attention layers with {attn_op_name} op", ranks=0)
 
     # Shard other parameters if MP group > 1.
     if sch.world_size > 1:

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -3,14 +3,12 @@
 
 import inspect
 
-import torch
 import torch.nn as nn
 from torch.distributed import distributed_c10d as dist
 
 import slapo
 from slapo import init_empty_weights
-from slapo.pattern import call_module
-from slapo.op.linear import FusedQKV
+from slapo.op import FlashSelfAttention, FlashAttentionOp, FusedMLP
 from slapo import init_empty_weights, get_cuda_rng_tracker
 
 
@@ -55,32 +53,35 @@ def replace_and_shard_attention(
     disable_flash_attn=False,
     sequence_parallel=False,
 ):
-    from epoi.inject.policy.gpt import InjectHFGPTAttentionPolicy
-    from epoi.ops.xformers_attn import GenericSelfAttention, MemoryEfficientAttentionOp
-
-    try:
-        # Backward compatibility
-        from epoi.ops.flash_attention import FlashSelfAttention, FlashAttentionTritonOp
-    except ImportError:
-        FlashSelfAttention = None
-        FlashAttentionTritonOp = None
-
-    cuda_sm = torch.cuda.get_device_capability("cuda")
-    if not disable_flash_attn and FlashSelfAttention is not None and cuda_sm == (8, 0):
-        SelfAttentionModule = FlashSelfAttention
-        AttentionOp = FlashAttentionTritonOp
-        attn_op_name = "triton"
-    else:
-        SelfAttentionModule = GenericSelfAttention
-        AttentionOp = MemoryEfficientAttentionOp
-        attn_op_name = "native" if disable_flash_attn else "cutlass"
+    attn_op_name = "native_xformers" if disable_flash_attn else "triton"
+    init_config = dict(
+        hidden_size=config.hidden_size,
+        num_attention_heads=config.num_attention_heads,
+        is_decoder=True,
+        attn_pdrop=config.attention_dropout,
+        resid_pdrop=config.resid_dropout,
+        attn_op_name=attn_op_name,
+        fused_qkv=True,
+    )
 
     class SelfAttention(nn.Module):
         """A wrapper to align the original GPTNeoAttention forward signature."""
 
         def __init__(self, **kwargs):
             super().__init__()
-            self.module = SelfAttentionModule(**kwargs)
+            try:
+                self.module = FlashSelfAttention(**kwargs)
+            except Exception as err:
+                if kwargs["attn_op_name"] == "native_xformers":
+                    raise RuntimeError(
+                        f"Failed to create native attention: {err}"
+                    ) from None
+
+                # Failed to use the triton kernel. This may due to unsupported
+                # GPU (< sm_75) or flash-attention is not installed. Fallback
+                # to xFormers' cutlass.
+                kwargs["attn_op_name"] = "cutlass"
+                self.module = FlashSelfAttention(**kwargs)
 
         def forward(
             self,
@@ -91,61 +92,55 @@ def replace_and_shard_attention(
             use_cache=False,
             output_attentions=False,
         ):
-            outputs = self.module(hidden_states, attention_mask, layer_past, use_cache)
+            """Match the original GPTNeoAttention forward signature."""
+            outputs = self.module(
+                hidden_states,
+                layer_past,
+                attention_mask,
+                head_mask,
+                None,
+                None,
+                use_cache,
+                output_attentions,
+            )
             # FIXME: The original output is (hidden_states, None) where the None
             # is present_key_value and only used by in inference.
             return outputs[:1]
 
-    class MemoryEfficientAttentionWithRNGOp(AttentionOp):
+    class AttentionOpWithRNG(FlashAttentionOp):
         def forward(self, query_layer, key_layer, value_layer, attention_mask, p):
             with get_cuda_rng_tracker().fork():
                 return super().forward(
                     query_layer, key_layer, value_layer, attention_mask, p
                 )
 
-    num_layers, num_heads, hidden_size = (
-        config.num_layers,
-        config.num_heads,
-        config.hidden_size,
-    )
-
     cnt = 0
-    for idx in range(num_layers):
+    for idx in range(config.num_layers):
         sub_sch = sch[attn_path.replace("N", str(idx))]
-        init_config = InjectHFGPTAttentionPolicy.gen_init_config_from_object(
-            sub_sch.mod, attn_op_name=attn_op_name
-        )
         with init_empty_weights(enable=delay_init):
             new_mod = SelfAttention(**init_config)
         sub_sch.replace(new_mod)
         sub_sch.trace(
             tracer="pytorch",
-            leaf_modules=[AttentionOp.__name__],
+            leaf_modules=["FlashAttentionOp"],
             concrete_args={
                 "layer_past": None,
+                "head_mask": None,
+                "encoder_hidden_states": None,
+                "encoder_attention_mask": None,
                 "use_cache": False,
+                "output_attentions": False,
             },
         )
 
-        def pattern(x: torch.Tensor) -> torch.Tensor:
-            x = call_module("query|key|value", x)
-            new_x_shape = x.size()[:-1] + (num_heads, hidden_size)
-            x = x.view(new_x_shape)
-            return x
-
-        subgraphs = sub_sch["module"].find(pattern)
-        assert len(subgraphs) == 3
-        with init_empty_weights(enable=delay_init):
-            new_fused_qkv = FusedQKV(hidden_size, num_heads, sch.world_size)
-        sub_sch["module"].replace(new_fused_qkv, subgraphs)
         if sch.world_size > 1:
-            sub_sch["module.FusedQKV_0.fused_linear"].shard("weight", axis=0)
-            sub_sch["module.FusedQKV_0.fused_linear"].shard("bias", axis=0)
+            sub_sch["module.qkv"].shard("weight", axis=0)
+            sub_sch["module.qkv"].shard("bias", axis=0)
             sub_sch["module.out_proj"].shard("weight", axis=1)
             fix_attention_mask_shape(sub_sch["module"])
 
             if sequence_parallel:
-                sub_sch["module.FusedQKV_0.fused_linear"].sync(
+                sub_sch["module.qkv"].sync(
                     mode="fwd_pre", sync_op_or_fn="all_gather", axis=1
                 )
 
@@ -154,18 +149,17 @@ def replace_and_shard_attention(
                 )
             else:
                 # Shard qkv and output projection.
-                sub_sch["module.FusedQKV_0.fused_linear"].sync(
-                    mode="bwd_post", sync_op_or_fn="all_reduce"
-                )
+                sub_sch["module.qkv"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
                 sub_sch["module.out_proj"].sync(
                     mode="fwd_post", sync_op_or_fn="all_reduce"
                 )
 
                 # In this case, the attention dropout in between has to
                 # use different random seeds.
-                new_op = MemoryEfficientAttentionWithRNGOp(
+                new_op = AttentionOpWithRNG(
                     sub_sch["module"]["attn_op"].mod.attn_op_name,
                     sub_sch["module"]["attn_op"].mod.apply_causal_mask,
+                    sub_sch["module"]["attn_op"].mod.scale,
                 )
                 sub_sch["module"]["attn_op"].replace(new_op)
 
@@ -235,14 +229,18 @@ def replace_and_shard_mlp(
     delay_init=True,
     sequence_parallel=False,
 ):
-    from epoi.inject.policy.gpt import InjectHFGPTMLPPolicy
-
     for idx in range(config.num_layers):
         prefix = path.replace("N", str(idx))
         if config.activation_function in ["gelu", "gelu_new"]:
             sub_sch = sch[prefix]
+            inter_size, hidden_size = sub_sch.mod.c_fc.weight.shape
             with init_empty_weights(enable=delay_init):
-                new_mod = InjectHFGPTMLPPolicy.init_from_object(sub_sch.mod)
+                new_mod = FusedMLP(
+                    hidden_size,
+                    inter_size,
+                    config.activation_function,
+                    config.resid_dropout,
+                )
             sub_sch.replace(new_mod)
             sub_sch.trace(leaf_modules=["FusedBiasGELU", "FusedBiasNewGELU"])
 

--- a/slapo/op/__init__.py
+++ b/slapo/op/__init__.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Custom Ops."""
+from .attention import FlashSelfAttention
 from .cross_entropy import ParallelCrossEntropy
 from .dropout import DropoutWithTensorParallel

--- a/slapo/op/__init__.py
+++ b/slapo/op/__init__.py
@@ -1,6 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Custom Ops."""
-from .attention import FlashSelfAttention
+from .attention import FlashSelfAttention, FlashAttentionOp
+from .bias_gelu import FusedBiasGELU, FusedBiasNewGELU
 from .cross_entropy import ParallelCrossEntropy
 from .dropout import DropoutWithTensorParallel
+from .linear import FusedQKV
+from .mlp import FusedMLP

--- a/slapo/op/attention.py
+++ b/slapo/op/attention.py
@@ -1,0 +1,423 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Attention module using high efficient CUDA kernels."""
+# pylint: disable=too-many-arguments, too-many-instance-attributes
+from __future__ import annotations
+
+import math
+from functools import partial
+from typing import Optional
+
+import torch
+from torch import nn
+
+from ..logger import get_logger
+from ..utils.common import importlib_or_none
+
+logger = get_logger()
+
+ATTN_GLOBAL_MSGS = set()
+
+
+def warning_once(msg):
+    """Log the warning message only once."""
+    if msg not in ATTN_GLOBAL_MSGS:
+        logger.warning(msg)
+        ATTN_GLOBAL_MSGS.add(msg)
+
+
+def flash_attn_ref(
+    q,
+    k,
+    v,
+    bias=None,
+    causal=False,
+    dropout_p=0.0,
+    softmax_scale=None,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    dropout_mask=None,
+    upcast=True,
+    reorder_ops=False,
+):
+    """The functional equivalent of FlashAttentionTriton for correctness checking.
+    Source: https://github.com/jfc4050/flash-attention/commit/f52868287ca9bd3ac1598dad6ce818358c1beafc
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Shape: (batch_size, seqlen_q, nheads, head_dim)
+    k : torch.Tensor
+        Shape: (batch_size, seqlen_k, nheads, head_dim)
+    v : torch.Tensor
+        Shape: (batch_size, seqlen_k, nheads, head_dim)
+    bias : Optional[torch.Tensor]
+        Shape: (batch_size, nheads, seqlen_q, seqlen_k)
+    causal : bool
+        Whether to apply lower triangular causal mask.
+    dropout_p: float
+        The dropout probability.
+    softmax_scale : Optional[float]
+        The softmax scale. If None, use 1 / sqrt(d).
+    query_padding_mask : Optional[torch.Tensor]
+        Shape: (batch_size, seqlen_q)
+    key_padding_mask : Optional[torch.Tensor]
+        (batch_size, seqlen_k)
+    dropout_mask: Optional[torch.Tensor]
+        The dropout mask. Shape: (batch_size, nheads, seqlen_q, seqlen_k)
+    upcast : bool
+        Whether to cast all inputs to fp32, do all computation in fp32, then cast
+        output back to fp16/bf16.
+    reorder_ops : bool
+        whether to change the order of operations (scaling k instead of scaling k, etc.)
+        without changing the math. This is to estimate the numerical error from
+        operation reordering.
+
+    Returns
+    -------
+    torch.Tensor
+        Shape: (batch_size, seqlen_q, nheads, head_dim)
+    """
+    assert softmax_scale is None, "softmax_scale is not supported"
+    einops = importlib_or_none("einops")
+    assert einops is not None, "einops is not installed"
+    rearrange = einops.rearrange
+
+    dtype_og = q.dtype
+    if upcast:
+        q, k, v = q.float(), k.float(), v.float()
+    seqlen_q, seqlen_k = q.shape[1], k.shape[1]
+    d = q.shape[-1]
+    if not reorder_ops:
+        scores = torch.einsum("bthd,bshd->bhts", q / math.sqrt(d), k)
+    else:
+        scores = torch.einsum("bthd,bshd->bhts", q, k / math.sqrt(d))
+    if bias is not None:
+        scores = (scores + bias).to(dtype=scores.dtype)
+    if key_padding_mask is not None:
+        scores.masked_fill_(
+            rearrange(~key_padding_mask, "b s -> b 1 1 s"), float("-inf")
+        )
+    if causal:
+        causal_mask = torch.triu(
+            torch.ones(seqlen_q, seqlen_k, dtype=torch.bool, device=q.device), 1
+        )
+        scores.masked_fill_(causal_mask, float("-inf"))
+    attention = torch.softmax(scores, dim=-1)
+    dropout_scaling = 1.0 / (1 - dropout_p)
+    # attention_drop = attention.masked_fill(~dropout_mask, 0.0) * dropout_scaling
+    # output = torch.einsum('bhts,bshd->bthd', attention_drop , v)
+    if dropout_mask is not None:
+        attention_drop = attention.masked_fill(~dropout_mask, 0.0)
+    else:
+        attention_drop = attention
+    output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
+    if query_padding_mask is not None:
+        output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
+        attention = attention.masked_fill(
+            rearrange(~query_padding_mask, "b s -> b 1 s 1"), 0.0
+        )
+    return output.to(dtype=dtype_og)
+
+
+def xformers_ref(q, k, v, attn_bias, p=0.0, scale=None):
+    """The native PyTorch implementation of attention with the same signature as the
+    attention implemented in xformers. This is used mainly to check the correctness
+    of the xformers implementation.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Shape: (batch_size, seqlen_q, nheads, head_dim)
+    k : torch.Tensor
+        Shape: (batch_size, seqlen_k, nheads, head_dim)
+    v : torch.Tensor
+        Shape: (batch_size, seqlen_k, nheads, head_dim)
+    attn_bias : Optional[torch.Tensor]
+        Shape: (batch_size, nheads, seqlen_q, seqlen_k)
+    p : float
+        The dropout probability.
+    scale : Optional[float]
+        The softmax scale. If None, use 1 / sqrt(d).
+
+    Returns
+    -------
+    torch.Tensor
+        Shape: (batch_size, seqlen_q, nheads, head_dim)
+    """
+    xformers_ops = importlib_or_none("xformers.ops")
+    assert xformers_ops is not None, "xformers is not installed"
+    assert q.ndim == 4
+
+    def attention_bmk(q, k, v, attn_bias=None, p=0.0, scale=None):
+        assert q.ndim == 3
+        q = q.float()
+        k = k.float()
+        v = v.float()
+
+        scale = scale if scale is not None else (1 / q.shape[-1] ** 0.5)
+        q = q * scale
+
+        attn = q @ k.transpose(-2, -1)
+        if attn_bias is not None:
+            if attn_bias.ndim == 4:
+                assert q.shape[0] == attn_bias.shape[0] * attn_bias.shape[1]
+                attn_bias = attn_bias.reshape([-1, *attn_bias.shape[2:]])
+            attn = attn + attn_bias.float()
+        attn = attn.softmax(-1).to(q.dtype)
+        if p > 0:
+            attn = torch.nn.functional.dropout(attn, p=p)
+        return attn @ v
+
+    def T(t):
+        return t.permute((0, 2, 1, 3)).reshape(
+            [t.shape[0] * t.shape[2], t.shape[1], t.shape[3]]
+        )
+
+    if isinstance(attn_bias, xformers_ops.AttentionBias):
+        attn_bias = attn_bias.materialize(
+            (q.shape[0], q.shape[2], q.shape[1], k.shape[1]),
+            device=q.device,
+            dtype=q.dtype,
+        ).reshape([q.shape[0] * q.shape[2], q.shape[1], k.shape[1]])
+    out = attention_bmk(T(q), T(k), T(v), attn_bias, p, scale=scale)
+    out = out.reshape([q.shape[0], q.shape[2], q.shape[1], v.shape[3]])
+    return out.permute((0, 2, 1, 3))
+
+
+def get_xfoemers_attn_op_by_name(attn_name):
+    """Get the xformers attention operator by name."""
+    xformers_ops = importlib_or_none("xformers.ops")
+    if xformers_ops is None:
+        raise RuntimeError("xformers is not installed")
+
+    ops = [
+        (xformers_ops.fmha.cutlass.FwOp, xformers_ops.fmha.cutlass.BwOp),
+        (xformers_ops.fmha.flash.FwOp, xformers_ops.fmha.flash.BwOp),
+        (xformers_ops.fmha.triton.FwOp, xformers_ops.fmha.triton.BwOp),
+        (xformers_ops.fmha.small_k.FwOp, xformers_ops.fmha.small_k.BwOp),
+    ]
+    target_op = None
+    if attn_name is not None and attn_name != "auto":
+        for op in ops:
+            if f"{attn_name}F" == op[0].NAME:
+                target_op = op
+                break
+        else:
+            raise ValueError(f"Unknown attention op name: {attn_name}")
+    return partial(xformers_ops.memory_efficient_attention, op=target_op)
+
+
+class FlashAttentionOp(nn.Module):
+    """A wrapper module that processes HF attention mask to flash attention mask."""
+
+    def __init__(self, attn_op_name, apply_causal_mask, scale=None):
+        super().__init__()
+        self.attn_op_name = attn_op_name
+        self.apply_causal_mask = apply_causal_mask
+        self.scale = scale
+        self.pkg = None
+
+        if attn_op_name == "native_xformers":
+            self.pkg = "xformers"
+            self.attn_fn = partial(xformers_ref, scale=scale)
+        elif attn_op_name == "native_flash_attn":
+            self.pkg = "flash_attn"
+            self.attn_fn = partial(
+                flash_attn_ref,
+                query_padding_mask=None,
+                key_padding_mask=None,
+                dropout_mask=None,
+                upcast=True,
+                reorder_ops=False,
+            )
+        elif attn_op_name == "triton":
+            self.pkg = "flash_attn"
+            cuda_sm = torch.cuda.get_device_capability("cuda")
+            if cuda_sm not in {(7, 5), (8, 0)}:
+                raise RuntimeError(
+                    f"flash_attn_triton is only supported on GPUs with sm_75 or sm_80, "
+                    f"but got sm_{cuda_sm[0]}{cuda_sm[1]}"
+                )
+            flash_attn_triton = importlib_or_none("flash_attn.flash_attn_triton")
+            if flash_attn_triton is None:
+                raise RuntimeError("flash_attn is not installed")
+            self.attn_fn = flash_attn_triton.flash_attn_func
+        else:
+            self.pkg = "xformers"
+            # When op=None, the xformers attention op will be automatically selected.
+            self.attn_fn = partial(
+                get_xfoemers_attn_op_by_name(attn_op_name), scale=scale
+            )
+
+        # Different kernels have different requirements on the bias layout.
+        self.bias_layout = "b11k" if self.pkg == "flash_attn" else "bhqk"
+
+    def forward(self, query_layer, key_layer, value_layer, attention_mask, p):
+        if self.pkg == "xformers":
+            if self.apply_causal_mask:
+                xformers_ops = importlib_or_none("xformers.ops")
+                attn_bias = xformers_ops.fmha.attn_bias.LowerTriangularMask()
+                if attention_mask is not None:
+                    attn_bias = attn_bias.add_bias(attention_mask)
+            else:
+                attn_bias = attention_mask
+
+            ret = self.attn_fn(query_layer, key_layer, value_layer, attn_bias, p=p)
+        else:
+            assert self.pkg == "flash_attn"
+            if self.attn_op_name == "triton" and attention_mask is not None:
+                warning_once(
+                    "WARNING: bias gradient is not supported yet. "
+                    "The given mask will be ignored"
+                )
+                attn_bias = None
+            else:
+                attn_bias = attention_mask
+
+            ret = self.attn_fn(
+                query_layer,
+                key_layer,
+                value_layer,
+                attn_bias,  # bias
+                self.apply_causal_mask,  # causal
+                p,  # dropout_p
+                self.scale,  # softmax_scale
+            )
+        ret = ret.to(query_layer.dtype)
+        return ret
+
+
+class FlashSelfAttention(nn.Module):
+    """A HuggingFace self attention module with flash attention kernels.
+    Note that this module has limited supports to specialized processing, documetned as follows:
+    - Only support absolute positional embeddings.
+    - Do not support cross attention.
+    - Do not support head mask, encoder_attention_mask, and output attention.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        num_attention_heads,
+        is_decoder,
+        attn_pdrop=0.0,
+        resid_pdrop=0.0,
+        attn_op_name="auto",
+        fused_qkv=False,
+    ):
+        super().__init__()
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                f"The hidden size ({hidden_size}) is not a multiple "
+                f"of the number of attention heads ({num_attention_heads})"
+            )
+
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_size = int(hidden_size / num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.fused_qkv = fused_qkv
+        if fused_qkv:
+            self.qkv = nn.Linear(hidden_size, 3 * self.all_head_size)
+        else:
+            self.query = nn.Linear(hidden_size, self.all_head_size)
+            self.key = nn.Linear(hidden_size, self.all_head_size)
+            self.value = nn.Linear(hidden_size, self.all_head_size)
+
+        self.is_decoder = is_decoder
+        self.attn_pdrop = attn_pdrop
+
+        if self.is_decoder:
+            self.out_proj = nn.Linear(hidden_size, hidden_size)
+            self.resid_dropout = nn.Dropout(resid_pdrop)
+
+        self.attn_op = FlashAttentionOp(attn_op_name, self.is_decoder)
+
+    @staticmethod
+    def layout_attention_mask(mask, num_attention_heads):
+        # (B, 1, 1, S) -> (B, H, S, S)
+        # Note that we use expand instead of repeat to avoid actual memory copy.
+        mask = mask.expand(-1, num_attention_heads, mask.shape[-1], -1)
+        return mask.contiguous()
+
+    def reshape_for_scores(self, x: torch.Tensor) -> torch.Tensor:
+        """Copy from transpose_for_scores but without the transpose"""
+        new_x_shape = x.size()[:-1] + (
+            self.num_attention_heads,
+            self.attention_head_size,
+        )
+        x = x.view(new_x_shape)
+        return x
+
+    def forward(
+        self,
+        hidden_states: Optional[tuple[torch.FloatTensor]],
+        layer_past: Optional[tuple[torch.Tensor]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = False,
+        output_attentions: Optional[bool] = False,
+    ) -> tuple[torch.Tensor]:
+        """The forward signature aligns to HuggingFace GPT-2."""
+        if encoder_hidden_states is not None or encoder_attention_mask is not None:
+            raise NotImplementedError(
+                "FlashSelfAttention does not support cross attention yet."
+            )
+        if output_attentions:
+            raise NotImplementedError(
+                "FlashSelfAttention does not support output attention yet."
+            )
+        if head_mask is not None:
+            raise NotImplementedError(
+                "FlashSelfAttention does not support head mask yet."
+            )
+
+        if self.fused_qkv:
+            query_layer, key_layer, value_layer = self.qkv(hidden_states).split(
+                self.hidden_size, dim=2
+            )
+        else:
+            query_layer = self.query(hidden_states)
+            key_layer = self.key(hidden_states)
+            value_layer = self.value(hidden_states)
+        query_layer = self.reshape_for_scores(query_layer)
+        key_layer = self.reshape_for_scores(key_layer)
+        value_layer = self.reshape_for_scores(value_layer)
+
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            key_layer = torch.cat((past_key, key_layer), dim=-2)
+            value_layer = torch.cat((past_value, value_layer), dim=-2)
+
+        if attention_mask is not None and self.attn_op.bias_layout == "bhqk":
+            # Required bias layout: [batch_size, #heads, seq_length, seq_length].
+            # The input shape is [batch_size, 1, 1, seq_length].
+            # In other words, we need to broadcast other dimensions manually.
+            attention_mask = self.layout_attention_mask(
+                attention_mask, self.num_attention_heads
+            )
+
+        context_layer = self.attn_op(
+            query_layer.contiguous(),
+            key_layer.contiguous(),
+            value_layer.contiguous(),
+            attention_mask,
+            p=self.attn_pdrop,
+        )
+        context_layer = context_layer.contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (-1,)
+        context_layer = context_layer.view(new_context_layer_shape)
+
+        if self.is_decoder:
+            context_layer = self.out_proj(context_layer)
+            context_layer = self.resid_dropout(context_layer)
+
+        if use_cache:
+            outputs = (context_layer, (key_layer, value_layer))
+        else:
+            outputs = (context_layer, None)
+        return outputs

--- a/slapo/op/attention.py
+++ b/slapo/op/attention.py
@@ -1,6 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Attention module using high efficient CUDA kernels."""
+"""Attention module using high efficient CUDA kernels.
+
+The flash-attention kernel is tested with:
+https://github.com/jfc4050/flash-attention/commit/528c70e
+
+The xFormers kernel is tested with:
+https://github.com/facebookresearch/xformers/commit/48a77cc
+
+If you encounter an error when using above kernels, please check if the
+commit hash is the same as the one we tested with.
+"""
 # pylint: disable=too-many-arguments, too-many-instance-attributes
 from __future__ import annotations
 
@@ -290,7 +300,8 @@ class FlashAttentionOp(nn.Module):
 
 class FlashSelfAttention(nn.Module):
     """A HuggingFace self attention module with flash attention kernels.
-    Note that this module has limited supports to specialized processing, documetned as follows:
+    Note that this module has limited supports to specialized processing,
+    documetned as follows:
     - Only support absolute positional embeddings.
     - Do not support cross attention.
     - Do not support head mask, encoder_attention_mask, and output attention.

--- a/slapo/op/attention.py
+++ b/slapo/op/attention.py
@@ -88,6 +88,7 @@ def flash_attn_ref(
     torch.Tensor
         Shape: (batch_size, seqlen_q, nheads, head_dim)
     """
+    # pylint: disable=invalid-unary-operand-type
     assert softmax_scale is None, "softmax_scale is not supported"
     einops = importlib_or_none("einops")
     assert einops is not None, "einops is not installed"

--- a/slapo/op/bias_gelu.py
+++ b/slapo/op/bias_gelu.py
@@ -1,0 +1,118 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""BiasGeLU module using with fused kernels."""
+# pylint: disable=too-many-arguments, too-many-instance-attributes
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from functorch.compile import memory_efficient_fusion
+except:
+    memory_efficient_fusion = None
+
+
+class BiasGeLUFunction(torch.autograd.Function):
+    """Bias+GeLU. Copied from Megatron-LM."""
+
+    @torch.jit.script
+    def bias_gelu(bias, y):
+        x = bias + y
+        return x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+
+    # gradient of tanh approximation of gelu
+    # gradient of actual gelu is:
+    # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+    @torch.jit.script
+    def bias_gelu_back(g, bias, y):
+        x = bias + y
+        tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+        # sqrt(2/pi) * 3 * 0.044715 -> 0.1070322243
+        ff = 0.5 * x * (
+            (1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * x * x)
+        ) + 0.5 * (1 + tanh_out)
+        return ff * g
+
+    @staticmethod
+    # bias is an optional argument
+    def forward(ctx, input, bias):
+        ctx.save_for_backward(input, bias)
+        return BiasGeLUFunction.bias_gelu(bias, input)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, bias = ctx.saved_tensors
+        tmp = BiasGeLUFunction.bias_gelu_back(grad_output, bias, input)
+        return tmp, tmp
+
+
+class FusedBiasGELU(torch.nn.Module):
+    def __init__(self, size, device=None, dtype=None, prev_weight=None, fused=True):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.empty(size, **factory_kwargs))
+        self.fused = fused
+        self.reset_parameters(prev_weight)
+
+    def reset_parameters(self, prev_weight=None):
+        range = (0, 1)
+        if prev_weight is not None:
+            fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(prev_weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            range = (-bound, bound)
+        torch.nn.init.uniform_(self.bias, *range)
+
+    def forward(self, input):
+        if self.fused:
+            return BiasGeLUFunction.apply(input, self.bias)
+        return F.gelu(input + self.bias, approximate="none")
+
+
+def new_gelu(input):
+    """New GELU activation function copied from HuggingFace transformers."""
+    return (
+        0.5
+        * input
+        * (
+            1.0
+            + torch.tanh(
+                math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))
+            )
+        )
+    )
+
+
+def bias_new_gelu(input, bias):
+    return new_gelu(input + bias)
+
+
+class FusedBiasNewGELU(torch.nn.Module):
+    def __init__(
+        self, size, device=None, dtype=None, prev_weight=None, fused=True, aot=True
+    ):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.empty(size, **factory_kwargs))
+        self.fused = fused
+        self.reset_parameters(prev_weight)
+        if self.fused:
+            if aot and memory_efficient_fusion is not None:
+                self.func = memory_efficient_fusion(bias_new_gelu)
+            else:
+                self.func = torch.jit.script(bias_new_gelu)
+        else:
+            self.func = bias_new_gelu
+
+    def reset_parameters(self, prev_weight=None):
+        range = (0, 1)
+        if prev_weight is not None and len(prev_weight.shape) > 1:
+            fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(prev_weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            range = (-bound, bound)
+        torch.nn.init.uniform_(self.bias, *range)
+
+    def forward(self, input):
+        return self.func(input, self.bias)

--- a/slapo/op/mlp.py
+++ b/slapo/op/mlp.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """MLP module using with fused kernels."""
-# pylint: disable=too-many-arguments, too-many-instance-attributes
 from __future__ import annotations
 
 import torch

--- a/slapo/op/mlp.py
+++ b/slapo/op/mlp.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MLP module using with fused kernels."""
+# pylint: disable=too-many-arguments, too-many-instance-attributes
+from __future__ import annotations
+
+import torch
+from .bias_gelu import FusedBiasGELU, FusedBiasNewGELU
+
+
+class FusedMLP(torch.nn.Module):
+    """A wrapper MLP to make use of fused bias+gelu."""
+
+    def __init__(self, hidden_size, intermediate_size, orig_act, resid_pdrop):
+        super().__init__()
+        if orig_act == "gelu":
+            self.fc_in = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
+            self.act = FusedBiasGELU(intermediate_size, prev_weight=self.fc_in.weight)
+        elif orig_act == "gelu_new":
+            self.fc_in = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
+            self.act = FusedBiasNewGELU(
+                intermediate_size, prev_weight=self.fc_in.weight
+            )
+        else:
+            raise NotImplementedError(f"Unsupported activation: {orig_act}")
+
+        self.fc_out = torch.nn.Linear(intermediate_size, hidden_size)
+        self.dropout = torch.nn.Dropout(resid_pdrop)
+
+    def forward(self, hidden_states):
+        hidden_states = self.fc_in(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.fc_out(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        return hidden_states

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Common utilities used in schedule."""
+import importlib
+from functools import lru_cache
 from types import FunctionType
 
 
@@ -56,3 +58,12 @@ def transfer_hooks(old_mod, new_mod, hook_types=None):
 
 def is_lambda_function(obj):
     return isinstance(obj, FunctionType) and obj.__name__ == "<lambda>"
+
+
+@lru_cache()
+def importlib_or_none(name):
+    """Import the module if available, otherwise return None."""
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        return None

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Test custom ops. Note that attn test has to be invoked by torchrun since
+Test custom ops. Note that this test has to be invoked by torchrun since
 most custom ops are for tensor parallelism.
 """
 # pylint: disable=unused-argument

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Test custom ops. Note that this test has to be invoked by torchrun since
+Test custom ops. Note that attn test has to be invoked by torchrun since
 most custom ops are for tensor parallelism.
 """
 # pylint: disable=unused-argument
@@ -50,6 +50,112 @@ def test_dropout(init_dist):
     dist.all_reduce(out_reduced)
     with pytest.raises(Exception):
         torch.testing.assert_close(out * world_size, out_reduced)
+
+
+@pytest.mark.parametrize("op_name", ["cutlass", "triton"])
+@pytest.mark.parametrize("shape", [(4, 1024, 2048, 16, 50264)])
+def test_attention(op_name, shape):
+    try:
+        from transformers import AutoConfig
+        from transformers.models.gpt2.modeling_gpt2 import GPT2Attention
+    except ImportError:
+        pytest.skip(reason="transformers not installed")
+
+    batch_size, seq_len, hidden_size, num_heads, vocab_size = shape
+    config = AutoConfig.from_pretrained("gpt2-medium")
+    config.max_position_embeddings = seq_len
+    config.n_embed = config.hidden_size = hidden_size
+    config.n_head = config.num_attention_heads = num_heads
+    config.vocab_size = vocab_size
+
+    # Disable dropout for correctness checking.
+    config.attn_pdrop = 0.0
+    config.resid_pdrop = 0.0
+
+    def _init(attn_op_name, config):
+        if attn_op_name is None:
+            attn = GPT2Attention(config)
+        else:
+            try:
+                attn = op.FlashSelfAttention(
+                    hidden_size=config.hidden_size,
+                    num_attention_heads=config.num_attention_heads,
+                    is_decoder=True,
+                    attn_pdrop=config.attn_pdrop,
+                    resid_pdrop=config.resid_pdrop,
+                    attn_op_name=attn_op_name,
+                    fused_qkv=True,
+                )
+            except Exception as err:
+                pytest.skip(
+                    reason=f"{attn_op_name} is not available in this environment "
+                    f"for testing: {err}"
+                )
+        return attn.half().cuda()
+
+    def _run_forward_backward(func, inputs):
+        outs = func(*inputs)
+        target_out = []
+        target_grad = []
+        for out in outs:
+            if out is not None:
+                target_out.append(out)
+                target_grad.append(torch.ones_like(out))
+        torch.autograd.backward(target_out, target_grad)
+        torch.cuda.synchronize()
+        return outs
+
+    # Initialize the attention module.
+    attn_ref = _init(None, config)
+    attn = _init(op_name, config)
+
+    # Sync parameters. Note that GPT-2 uses fused QKV and Conv1D.
+    requires_grad = attn_ref.c_attn.weight.requires_grad
+    attn.qkv.weight = torch.nn.Parameter(
+        attn_ref.c_attn.weight.transpose(-1, 0).contiguous(),
+        requires_grad=requires_grad,
+    )
+    attn.qkv.bias = attn_ref.c_attn.bias
+    attn.out_proj.weight = torch.nn.Parameter(
+        attn_ref.c_proj.weight.transpose(-1, 0).contiguous(),
+        requires_grad=requires_grad,
+    )
+    attn.out_proj.bias = attn_ref.c_proj.bias
+
+    # Generate inputs.
+    hidden_states = torch.randn(
+        [batch_size, seq_len, hidden_size],
+        dtype=torch.float16,
+        device="cuda",
+        requires_grad=True,
+    )
+    attn_mask = torch.randn(
+        [batch_size, 1, 1, seq_len],
+        dtype=torch.float16,
+        device="cuda",
+        requires_grad=True,
+    )
+    inputs = [hidden_states, None, attn_mask]
+
+    # Run reference.
+    out_ref = _run_forward_backward(attn_ref, inputs)
+    grads_ref = [inp.grad for inp in inputs if inp is not None]
+
+    # Zero out gradients.
+    for inp in inputs:
+        if inp is not None:
+            inp.grad = None
+
+    # Run custom op.
+    out = _run_forward_backward(attn, inputs)
+    grads = [inp.grad for inp in inputs if inp is not None]
+
+    torch.testing.assert_close(out[0], out_ref[0], atol=5e-2, rtol=5e-2)
+    for grad, grad_ref in zip(grads, grads_ref):
+        if grad is None:
+            # Bias gradient is not supported yet.
+            continue
+        torch.testing.assert_close(grad, grad_ref, atol=5e-2, rtol=5e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -73,6 +73,7 @@ def test_attention(op_name, shape):
     config.resid_pdrop = 0.0
 
     def _init(attn_op_name, config):
+        # pylint: disable=redefined-variable-type
         if attn_op_name is None:
             attn = GPT2Attention(config)
         else:
@@ -88,7 +89,7 @@ def test_attention(op_name, shape):
                 )
             except Exception as err:
                 pytest.skip(
-                    reason=f"{attn_op_name} is not available in mlp environment "
+                    reason=f"{attn_op_name} is not available in this environment "
                     f"for testing: {err}"
                 )
         return attn.half().cuda()

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,19 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Test custom ops. Note that this test has to be invoked by torchrun since
+Test custom ops. Note that attn test has to be invoked by torchrun since
 most custom ops are for tensor parallelism.
 """
 # pylint: disable=unused-argument
 import os
-
 import pytest
+
 import torch
-from torch import distributed as dist
 from torch import nn
+from torch import distributed as dist
 
 from slapo import op
-from slapo.random import get_cuda_rng_tracker, set_random_seed
+from slapo.random import set_random_seed, get_cuda_rng_tracker
 
 
 def test_dropout(init_dist):
@@ -86,6 +86,7 @@ def test_attention(op_name, shape):
                     resid_pdrop=config.resid_pdrop,
                     attn_op_name=attn_op_name,
                     fused_qkv=True,
+                    world_size=1,
                 )
             except Exception as err:
                 pytest.skip(
@@ -157,68 +158,6 @@ def test_attention(op_name, shape):
             # Bias gradient is not supported yet.
             continue
         torch.testing.assert_close(grad, grad_ref, atol=5e-2, rtol=5e-2)
-
-
-@pytest.mark.parametrize("act_name", ["gelu", "gelu_new"])
-@pytest.mark.parametrize("shape", [(8, 512, 1024)])
-def test_mlp(act_name, shape):
-    try:
-        from transformers import AutoConfig
-        from transformers.models.gpt2.modeling_gpt2 import GPT2MLP
-    except ImportError:
-        pytest.skip(reason="transformers not installed")
-
-    batch_size, seq_len, hidden_size = shape
-    config = AutoConfig.from_pretrained("gpt2-medium")
-    config.max_position_embeddings = seq_len
-    config.n_embed = config.hidden_size = hidden_size
-    config.resid_pdrop = 0.0
-    config.activation_function = act_name
-    intermediate_size = 4 * hidden_size
-
-    def _run(func, hidden_states):
-        out = func(hidden_states)
-        torch.autograd.backward(out, torch.ones_like(out))
-        torch.cuda.synchronize()
-        grad = hidden_states.grad
-        hidden_states.grad = None
-        return out, grad
-
-    # Initialize the MLP module.
-    mlp_ref = GPT2MLP(intermediate_size, config).half().cuda()
-    mlp = op.FusedMLP(
-        config.hidden_size,
-        intermediate_size,
-        config.activation_function,
-        config.resid_pdrop,
-    )
-    mlp = mlp.half().cuda()
-
-    # Sync parameters. Note that GPT-2 uses Conv1D with transposed weights.
-    requires_grad = mlp_ref.c_fc.weight.requires_grad
-    mlp.fc_in.weight = torch.nn.Parameter(
-        mlp_ref.c_fc.weight.transpose(-1, 0).contiguous(), requires_grad=requires_grad
-    )
-    mlp.act.bias = mlp_ref.c_fc.bias
-    mlp.fc_out.weight = torch.nn.Parameter(
-        mlp_ref.c_proj.weight.transpose(-1, 0).contiguous(), requires_grad=requires_grad
-    )
-    mlp.fc_out.bias = mlp_ref.c_proj.bias
-
-    # Generate inputs.
-    hidden_states = torch.randn(
-        [batch_size, seq_len, hidden_size],
-        dtype=torch.float16,
-        device="cuda",
-        requires_grad=True,
-    )
-
-    # Run reference.
-    out_ref, grad_ref = _run(mlp_ref, hidden_states)
-    out, grad = _run(mlp, hidden_states)
-
-    torch.testing.assert_close(out, out_ref, atol=5e-2, rtol=5e-2)
-    torch.testing.assert_close(grad, grad_ref, atol=5e-2, rtol=5e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This is a prerequisite PR for adding HF GPT-2 schedule.

- Implement attention ops that use flash-attention and xformrs.
- Implement bias_gelu ops that use torchscript or torch compiler.
- Change the GPT-Neo schedule to use these ops, so that now GPT-Neo schedule doesn't depend on `epoi` anymore. Later we will update the schedules of other example models accordingly.
- [Test] Add `-rxXs` to let pytest print reasons of skipped tests.
- [Docker] Update flash-attention commit hash which improves the kernel performance by ~12%. CI image is not updated because this change doesn't impact the functionality.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

@szhengac @chhzh123 