### PR TITLE
[Tracer] Remove SelfAttention renaming

### DIFF
--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -1250,7 +1250,7 @@ def consolidate_model(
             # so no need to consolidate
             return
 
-        if hasattr(sch, "partition_idx"):
+        if hasattr(sch, "partition_idx") and topology is not None:
             curr_part_idx = sch.partition_idx
             # topology stores the global ranks
             curr_stage_devices = topology.filter_match(pipe=curr_part_idx)
@@ -1345,7 +1345,7 @@ def build(
         init_weight_fn = init_weights if isinstance(init_weights, Callable) else None
         sch = consolidate_model(sch, target, init_weight_fn, **kwargs)
 
-    if sch.metadata.pipeline_cutting_paths:
+    if sch.metadata.pipeline_cutting_paths and target is not None:
         # Generate pipeline modules for a particular target.
         model = build_pipeline_model(
             sch,


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #13 and #30 by removing the legacy code of renaming self attention module for HuggingFace models. As now we only trace the module when needed and also replace the attention module with our own module, the naming issue probably may not be a problem. We also do not refer to `self_m` in our example schedules, so I remove the renaming part from the tracer, and only prompt a warning when the tracer meets those `self` modules.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @szhengac @comaniac 