### PR TITLE
[Op] Refactor qkv processing

### DIFF
--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -48,6 +48,7 @@ def reconfig_model(args, model_config):
         model_config.resid_dropout = args.dropout
         model_config.embed_dropout = args.dropout
 
+    model_config.activation_function = args.activation_function
     model_config.max_position_embeddings = args.seq_len
 
     return model_config
@@ -270,6 +271,12 @@ if __name__ == "__main__":
         type=int,
         default=1024,
         help="Sequence length",
+    )
+    parser.add_argument(
+        "--activation_function",
+        type=str,
+        default="gelu_new",
+        help="Activation function",
     )
     parser.add_argument(
         "--disable_pipeline",

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -45,7 +45,6 @@ def schedule_model(
 
     # Replace self attention with flash attention, and shard QKV/output
     # if MP group > 1.
-    attn_path, out_proj_name = "h.N.attn.attention", "out_proj"
     if disable_flash_attn:
         logger.info("Disabled Flash Attention", ranks=0)
     cnt, attn_op_name = replace_and_shard_attention(

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -242,7 +242,7 @@ def replace_and_shard_mlp(
         prefix = path.replace("N", str(idx))
         if config.activation_function in ["gelu", "gelu_new"]:
             sub_sch = sch[prefix]
-            inter_size, hidden_size = sub_sch.mod.c_fc.weight.shape
+            hidden_size, inter_size = sub_sch.mod.c_fc.weight.shape
             with init_empty_weights(enable=delay_init):
                 new_mod = FusedMLP(
                     hidden_size,

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -242,7 +242,7 @@ def replace_and_shard_mlp(
         prefix = path.replace("N", str(idx))
         if config.activation_function in ["gelu", "gelu_new"]:
             sub_sch = sch[prefix]
-            hidden_size, inter_size = sub_sch.mod.c_fc.weight.shape
+            inter_size, hidden_size = sub_sch.mod.c_fc.weight.shape
             with init_empty_weights(enable=delay_init):
                 new_mod = FusedMLP(
                     hidden_size,

--- a/examples/gpt2/model.py
+++ b/examples/gpt2/model.py
@@ -44,13 +44,13 @@ def schedule_model(
     # Replace self attention with flash attention.
     if disable_flash_attn:
         logger.info("Disabled Flash Attention", ranks=0)
-    cnt = replace_attention(
+    cnt, attn_op_name = replace_attention(
         sch[prefix],
         config,
         delay_init=delay_init,
         disable_flash_attn=disable_flash_attn,
     )
-    logger.info(f"Replaced {cnt} attention layers", ranks=0)
+    logger.info(f"Replace {cnt} attention layers with {attn_op_name} op", ranks=0)
 
     # Replace MLP with fused kernels.
     cnt = replace_mlp(sch[prefix], config, delay_init=delay_init)


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Pointed out by @szhengac, the current logic that uses `.chunk(3, dim=-1)` to split qkv assumes different data layouts for TP=1 and TP>1 cases. Specifically, when TP=1, we assume the qkv is contiguous, meaning that the weight layout is `[q0q1,...,k0k1, ..., v0v1]`. However, when TP>1, since weight is sharded along axis=0, each partitioned weight has `[3 * H // TP]`. This assumes the qkv layout is interleaved (i.e., `[q0k0v0, ...]`).

This won't be an issue if we always run the model within the same case, but the produces incorrect results if, for example, we trained the model with TP=2 but now want to fine-tune it with TP=1. Although transposing trained weights could also resolve this issue, this seems not straightforward to users.

This PR fixes this issue by assuming the qkv weights are always interleaved. This is also the methodology used in Megatron-LM. Accordingly, we need to manually transpose the weights in the unit test to match the GPT-2 attention results.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

