### PR TITLE
Add num_workers to GPT dataloader

### DIFF
--- a/examples/data_util.py
+++ b/examples/data_util.py
@@ -30,8 +30,7 @@ class LossTestDataset(Dataset):
 
 def collate_fn(batch, enable_pipeline=True):
     input_ids = torch.tensor([x[0] for x in batch], dtype=torch.long)
-    attention_mask = torch.tensor(
-        [x[1] for x in batch], dtype=torch.float16)
+    attention_mask = torch.tensor([x[1] for x in batch], dtype=torch.float16)
     position_ids = torch.stack([x[2] for x in batch])
     labels = torch.tensor([x[3] for x in batch], dtype=torch.long)
 

--- a/examples/data_util.py
+++ b/examples/data_util.py
@@ -5,6 +5,7 @@ from transformers import AutoTokenizer
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.distributed import DistributedSampler
 import torch
+from functools import partial
 
 
 class LossTestDataset(Dataset):
@@ -27,26 +28,21 @@ class LossTestDataset(Dataset):
         return ret
 
 
-def get_data_move_and_group_fn(enable_pipeline):
-    def _collate_fn(batch):
-        device = torch.cuda.current_device()
-        input_ids = torch.tensor([x[0] for x in batch], dtype=torch.long, device=device)
-        attention_mask = torch.tensor(
-            [x[1] for x in batch], dtype=torch.float16, device=device
-        )
-        position_ids = torch.stack([x[2] for x in batch]).to(device=device)
-        labels = torch.tensor([x[3] for x in batch], dtype=torch.long, device=device)
+def collate_fn(batch, enable_pipeline=True):
+    input_ids = torch.tensor([x[0] for x in batch], dtype=torch.long)
+    attention_mask = torch.tensor(
+        [x[1] for x in batch], dtype=torch.float16)
+    position_ids = torch.stack([x[2] for x in batch])
+    labels = torch.tensor([x[3] for x in batch], dtype=torch.long)
 
-        ret = [input_ids, attention_mask, position_ids, labels]
-        if not enable_pipeline:
-            # insert None in second and fourth position
-            ret.insert(1, None)  # past_key_values
-            ret.insert(3, None)  # token_type_ids
+    ret = [input_ids, attention_mask, position_ids, labels]
+    if not enable_pipeline:
+        # insert None in second and fourth position
+        ret.insert(1, None)  # past_key_values
+        ret.insert(3, None)  # token_type_ids
 
-        # group first inputs
-        return [ret[:-1], ret[-1]]
-
-    return _collate_fn
+    # group first inputs
+    return [ret[:-1], ret[-1]]
 
 
 def get_dataloader(
@@ -82,16 +78,20 @@ def get_dataloader(
         train_dataset,
         batch_size=micro_batch_size,
         sampler=DistributedSampler(train_dataset, num_replicas=num_replicas, rank=rank),
-        collate_fn=get_data_move_and_group_fn(enable_pipeline),
+        collate_fn=partial(collate_fn, enable_pipeline=enable_pipeline),
         drop_last=True,
+        num_workers=2,
+        pin_memory=True,
     )
 
     val_loader = DataLoader(
         val_dataset,
         batch_size=micro_batch_size,
         sampler=DistributedSampler(val_dataset, num_replicas=num_replicas, rank=rank),
-        collate_fn=get_data_move_and_group_fn(enable_pipeline),
+        collate_fn=partial(collate_fn, enable_pipeline=enable_pipeline),
         drop_last=True,
+        num_workers=2,
+        pin_memory=True,
     )
     return train_loader, val_loader
 

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -43,13 +43,13 @@ def reconfig_model(args, model_config):
         model_config.attention_types = [[["global"], model_config.num_layers]]
         model_config.attention_layers = ["global"] * model_config.num_layers
 
-    if args.dropout > 0:
-        model_config.attention_dropout = args.dropout
-        model_config.resid_dropout = args.dropout
-        model_config.embed_dropout = args.dropout
+    model_config.attention_dropout = args.dropout
+    model_config.resid_dropout = args.dropout
+    model_config.embed_dropout = args.dropout
 
     model_config.activation_function = args.activation_function
     model_config.max_position_embeddings = args.seq_len
+    model_config.activation_function = args.activation_function
 
     return model_config
 
@@ -135,13 +135,14 @@ def train(args):
             pipeline_cuts=pipeline_cuts,
             delay_init=enable_pipeline,
             sequence_parallel=args.sequence_parallel,
+            checkpoint_method=args.checkpoint_method,
         )
     tp_rank = sch.rank
 
     loss_fct = ParallelCrossEntropy(group=group)
 
     def loss_fn(outputs, labels):
-        prediction_scores = outputs.to(torch.float32)
+        prediction_scores = outputs
         shifted_prediction_scores = prediction_scores[..., :-1, :].contiguous()
         labels = labels[..., 1:].contiguous()
         lm_loss = loss_fct(shifted_prediction_scores, labels)
@@ -255,6 +256,12 @@ if __name__ == "__main__":
         help="Activation checkpointing ratio. 1.0 means all",
     )
     parser.add_argument(
+        "--checkpoint_method",
+        type=str,
+        default="uniform",
+        help="Activation checkpointing method {'head', 'uniform'}",
+    )
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=None,
@@ -322,6 +329,12 @@ if __name__ == "__main__":
         "--bf16",
         action="store_true",
         help="bf16 is enabled",
+    )
+    parser.add_argument(
+        "--activation_function",
+        type=str,
+        default="gelu_new",
+        help="Activation function",
     )
     args = parser.parse_args()
 

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -49,7 +49,6 @@ def reconfig_model(args, model_config):
 
     model_config.activation_function = args.activation_function
     model_config.max_position_embeddings = args.seq_len
-    model_config.activation_function = args.activation_function
 
     return model_config
 
@@ -329,12 +328,6 @@ if __name__ == "__main__":
         "--bf16",
         action="store_true",
         help="bf16 is enabled",
-    )
-    parser.add_argument(
-        "--activation_function",
-        type=str,
-        default="gelu_new",
-        help="Activation function",
     )
     args = parser.parse_args()
 

--- a/examples/gpt/deepspeed_hf.py
+++ b/examples/gpt/deepspeed_hf.py
@@ -258,7 +258,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--checkpoint_method",
         type=str,
-        default="uniform",
+        default="head",
         help="Activation checkpointing method {'head', 'uniform'}",
     )
     parser.add_argument(

--- a/examples/gpt/megatron_hf.py
+++ b/examples/gpt/megatron_hf.py
@@ -291,7 +291,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
 
 if __name__ == "__main__":
-
     pretrain(
         train_valid_test_datasets_provider,
         model_provider,

--- a/examples/gpt/model.py
+++ b/examples/gpt/model.py
@@ -30,6 +30,7 @@ def schedule_model(
     pipeline_cuts=None,
     delay_init=True,
     sequence_parallel=False,
+    checkpoint_method="uniform",
 ):
     assert "GPT2" not in config.architectures[0], "GPT-2 schedule is not working"
 
@@ -79,7 +80,12 @@ def schedule_model(
 
     # Insert activation checkpoints.
     if ckpt_ratio > 0.0:
-        n_ckpt = checkpoint(sch[prefix], config, ckpt_ratio=ckpt_ratio)
+        n_ckpt = checkpoint(
+            sch[prefix],
+            config,
+            ckpt_ratio=ckpt_ratio,
+            checkpoint_method=checkpoint_method,
+        )
         logger.info(f"Checkpointing {n_ckpt} layers", ranks=0)
 
     # Cut pipeline stages.

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -290,7 +290,7 @@ def replace_and_shard_mlp(
                 )
 
 
-def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0):
+def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
     if ckpt_ratio == 0.0:
         return
 
@@ -310,8 +310,12 @@ def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0):
         return (args[0], None, attention_mask, head_mask, False, output_attentions)
 
     n_ckpt = int(config.num_hidden_layers * ckpt_ratio)
-    for idx in range(n_ckpt):
-        sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
+    if method == "head":
+        for idx in range(n_ckpt):
+            sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
+    elif method == "uniform" and ckpt_ratio > 0:
+        for idx in range(0, config.num_hidden_layers, max(1, int(1 / ckpt_ratio))):
+            sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
     return n_ckpt
 
 

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -290,7 +290,7 @@ def replace_and_shard_mlp(
                 )
 
 
-def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
+def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, checkpoint_method="uniform"):
     if ckpt_ratio == 0.0:
         return
 
@@ -310,10 +310,10 @@ def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
         return (args[0], None, attention_mask, head_mask, False, output_attentions)
 
     n_ckpt = int(config.num_hidden_layers * ckpt_ratio)
-    if method == "head":
+    if checkpoint_method == "head":
         for idx in range(n_ckpt):
             sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
-    elif method == "uniform" and ckpt_ratio > 0:
+    elif checkpoint_method == "uniform" and ckpt_ratio > 0:
         for idx in range(0, config.num_hidden_layers, max(1, int(1 / ckpt_ratio))):
             sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
     return n_ckpt

--- a/examples/gpt2/deepspeed_hf.py
+++ b/examples/gpt2/deepspeed_hf.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--checkpoint_method",
         type=str,
-        default="uniform",
+        default="head",
         help="Activation checkpointing method {'head', 'uniform'}",
     )
     parser.add_argument(

--- a/examples/gpt2/deepspeed_hf.py
+++ b/examples/gpt2/deepspeed_hf.py
@@ -38,10 +38,9 @@ def reconfig_model(args, model_config):
         model_config.num_hidden_layers = args.nlayers
         model_config.num_attention_heads = args.num_attn_heads
 
-    if args.dropout > 0:
-        model_config.attn_pdrop = args.dropout
-        model_config.resid_pdrop = args.dropout
-        model_config.embd_pdrop = args.dropout
+    model_config.attn_pdrop = args.dropout
+    model_config.resid_pdrop = args.dropout
+    model_config.embd_pdrop = args.dropout
 
     model_config.activation_function = args.activation_function
     model_config.max_position_embeddings = args.seq_len
@@ -130,13 +129,14 @@ def train(args):
             pipeline_cuts=pipeline_cuts,
             delay_init=enable_pipeline,
             sequence_parallel=args.sequence_parallel,
+            checkpoint_method=args.checkpoint_method,
         )
     tp_rank = sch.rank
 
     loss_fct = ParallelCrossEntropy(group=group)
 
     def loss_fn(outputs, labels):
-        prediction_scores = outputs.to(torch.float32)
+        prediction_scores = outputs
         shifted_prediction_scores = prediction_scores[..., :-1, :].contiguous()
         labels = labels[..., 1:].contiguous()
         lm_loss = loss_fct(shifted_prediction_scores, labels)
@@ -250,6 +250,12 @@ if __name__ == "__main__":
         help="Activation checkpointing ratio. 1.0 means all",
     )
     parser.add_argument(
+        "--checkpoint_method",
+        type=str,
+        default="uniform",
+        help="Activation checkpointing method {'head', 'uniform'}",
+    )
+    parser.add_argument(
         "--batch_size",
         type=int,
         default=None,
@@ -297,7 +303,7 @@ if __name__ == "__main__":
         "--num-attn-heads", type=int, default=-1, help="Number of attention heads"
     )
     parser.add_argument(
-        "--dropout", type=float, default=0.0, help="Dropout probability"
+        "--dropout", type=float, default=0.1, help="Dropout probability"
     )
     parser.add_argument(
         "--pmp", type=int, default=2, help="Pipeline model parallel size"

--- a/examples/gpt2/model.py
+++ b/examples/gpt2/model.py
@@ -30,6 +30,7 @@ def schedule_model(
     pipeline_cuts=None,
     delay_init=True,
     sequence_parallel=False,
+    checkpoint_method="uniform",
 ):
     if fp16:
         logger.info("Change model dtype to fp16", ranks=0)
@@ -75,7 +76,12 @@ def schedule_model(
 
     # Insert activation checkpoints.
     if ckpt_ratio > 0.0:
-        n_ckpt = checkpoint(sch[prefix], config, ckpt_ratio=ckpt_ratio)
+        n_ckpt = checkpoint(
+            sch[prefix],
+            config,
+            ckpt_ratio=ckpt_ratio,
+            checkpoint_method=checkpoint_method,
+        )
         logger.info(f"Checkpointing {n_ckpt} layers", ranks=0)
 
     # Cut pipeline stages.

--- a/examples/gpt2/schedule.py
+++ b/examples/gpt2/schedule.py
@@ -357,7 +357,7 @@ def shard(
                 sub_sch[fc_names[2]].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
 
 
-def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0):
+def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
     """Add activation checkpointing to the model. The ckpt_ratio specifies
     the ratio of the attention layers to be checkpointed. For example, if
     ckpt_ratio is 0.5, then half of the attention layers will be checkpointed.
@@ -405,8 +405,12 @@ def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0):
         )
 
     n_ckpt = int(config.num_hidden_layers * ckpt_ratio)
-    for idx in range(n_ckpt):
-        sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
+    if method == "head":
+        for idx in range(n_ckpt):
+            sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
+    elif method == "uniform" and ckpt_ratio > 0:
+        for idx in range(0, config.num_hidden_layers, max(1, int(1 / ckpt_ratio))):
+            sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
     return n_ckpt
 
 

--- a/examples/gpt2/schedule.py
+++ b/examples/gpt2/schedule.py
@@ -357,7 +357,7 @@ def shard(
                 sub_sch[fc_names[2]].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
 
 
-def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
+def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, checkpoint_method="uniform"):
     """Add activation checkpointing to the model. The ckpt_ratio specifies
     the ratio of the attention layers to be checkpointed. For example, if
     ckpt_ratio is 0.5, then half of the attention layers will be checkpointed.
@@ -405,10 +405,10 @@ def checkpoint(sch, config, path="h.N", ckpt_ratio=1.0, method="uniform"):
         )
 
     n_ckpt = int(config.num_hidden_layers * ckpt_ratio)
-    if method == "head":
+    if checkpoint_method == "head":
         for idx in range(n_ckpt):
             sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
-    elif method == "uniform" and ckpt_ratio > 0:
+    elif checkpoint_method == "uniform" and ckpt_ratio > 0:
         for idx in range(0, config.num_hidden_layers, max(1, int(1 / ckpt_ratio))):
             sch[path.replace("N", str(idx))].checkpoint(order_args_fn=order_args_fn)
     return n_ckpt


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

The current GPT dataloader does not use prefetching. This PR fixes that by adding num_workers=2 and removes cuda in collate_fn, which will reinitialize cuda context in subprocesses.

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

