### PR TITLE
[Schedule] Create subschedule for subgraph replacement

### DIFF
--- a/examples/bert/schedule.py
+++ b/examples/bert/schedule.py
@@ -23,7 +23,7 @@ def fix_attention_mask_shape(sch):
         return out.contiguous()
 
     for op in ops:
-        sch.replace(new_expand, op[1])
+        sch.replace(new_expand, op)
 
 
 def replace_and_shard_attention(

--- a/examples/gpt/schedule.py
+++ b/examples/gpt/schedule.py
@@ -42,7 +42,7 @@ def fix_attention_mask_shape(sch):
         return out.contiguous()
 
     for op in ops:
-        sch.replace(new_expand, op[1])
+        sch.replace(new_expand, op)
 
 
 def replace_and_shard_attention(

--- a/examples/gpt2/schedule.py
+++ b/examples/gpt2/schedule.py
@@ -213,7 +213,7 @@ def fix_attention_mask_shape(sch):
         return out.contiguous()
 
     for op in ops:
-        sch.replace(new_expand, op[1])
+        sch.replace(new_expand, op)
 
 
 class AttentionOpWithRNG(FlashAttentionOp):

--- a/examples/opt/schedule.py
+++ b/examples/opt/schedule.py
@@ -42,7 +42,7 @@ def fix_attention_mask_shape(sch):
         return out.contiguous()
 
     for op in ops:
-        sch.replace(new_expand, op[1])
+        sch.replace(new_expand, op)
 
 
 def replace_and_shard_attention(
@@ -152,7 +152,7 @@ def remove_cast(sch, config, attn_path="h.N.attn.attention"):
         )
 
         for op in ops:
-            sub_sch.replace(lambda x, *args: x, op[1])
+            sub_sch.replace(lambda x, *args: x, op)
             cnt += 1
     return cnt
 

--- a/examples/roberta/schedule.py
+++ b/examples/roberta/schedule.py
@@ -41,7 +41,7 @@ def fix_attention_mask_shape(sch):
         return out.contiguous()
 
     for op in ops:
-        sch.replace(new_expand, op[1])
+        sch.replace(new_expand, op)
 
 
 def replace_and_shard_attention(

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -755,6 +755,7 @@ class SubgraphWrapper(nn.Module):
             node.replace_all_uses_with(new_node)
         self.mod.graph.erase_node(node)
 
+    # pylint: disable=too-many-branches
     def replace_module(self, new_mod, subgraphs=None, name=None):
         """Replace an entire module with a new one.
         Do NOT directly call this function, use `.replace()` instead.
@@ -893,7 +894,7 @@ class SubgraphWrapper(nn.Module):
                             transfer_hooks(old_mod, new_mod, ["fwd_pre", "bwd_post"])
                         elif i == len(ops) - 1:
                             transfer_hooks(old_mod, new_mod, ["fwd_post"])
-                        elif any([len(hooks[x]) > 0 for x in hook_types]):
+                        elif any(len(hooks[x]) > 0 for x in hook_types):
                             raise RuntimeError(
                                 f"Cannot transfer hooks from {node.target} to {name} since the {node.target} is in the middle of the subgraph"
                             )

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -786,6 +786,7 @@ class SubgraphWrapper(nn.Module):
             name = _get_unique_module_name(self.mod, name)
         # Create a new schedule for the replaced module
         new_sch = create_schedule(new_mod, name, self.path, self.parent, self.group)
+        hook_types = ["fwd_pre", "fwd_post", "bwd_post"]
         # Replace the corresponding part in the current module
         if subgraphs is None:
             # If subgraphs is None, replace the whole self module.
@@ -838,7 +839,6 @@ class SubgraphWrapper(nn.Module):
                             target_mod.graph.erase_node(node)
                 # Since horizontal fusion needs to combine the hooks together,
                 # we cannot support it for now.
-                hook_types = ["fwd_pre", "fwd_post", "bwd_post"]
                 for i, sublst in enumerate(subgraphs):
                     for _, node in sublst:
                         if node.op == "call_module":

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -6,6 +6,13 @@ from functools import lru_cache
 from types import FunctionType
 
 
+HOOK_TYPE_TO_ATTR = {
+    "fwd_pre": "_forward_pre_hooks",
+    "fwd_post": "_forward_hooks",
+    "bwd_post": "_backward_hooks",
+}
+
+
 def get_hooks(mod):
     """Get the hooks of a module.
 
@@ -32,6 +39,10 @@ def get_hooks(mod):
     return hooks
 
 
+def has_hook(mod, hook_type):
+    return len(getattr(mod, HOOK_TYPE_TO_ATTR[hook_type])) > 0
+
+
 def transfer_hooks(old_mod, new_mod, hook_types=None):
     """Transfer the hooks from old_mod to new_mod.
 
@@ -44,11 +55,6 @@ def transfer_hooks(old_mod, new_mod, hook_types=None):
     hook_types : Optional[List[str]]
         The types of hooks to transfer. If None, transfer all hooks.
     """
-    HOOK_TYPE_TO_ATTR = {
-        "fwd_pre": "_forward_pre_hooks",
-        "fwd_post": "_forward_hooks",
-        "bwd_post": "_backward_hooks",
-    }
     if hook_types is None:
         hook_types = ["fwd_pre", "fwd_post", "bwd_post"]
 

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -62,6 +62,59 @@ def transfer_hooks(old_mod, new_mod, hook_types=None):
         setattr(new_mod, hook_attr, getattr(old_mod, hook_attr))
 
 
+def transfer_hooks_for_fusion(sch, subgraphs, new_mod):
+    """Transfer hooks of modules in the subgraph to be fused.
+    For example, the fwd_pre hook of the first module in the subgraph will become
+    the fwd_pre hook of the fused module.
+    Note that if middle modules have hooks, we will throw errors because we cannot
+    keep these hooks in the fused module.
+
+    Parameters
+    ----------
+    sch : Schedule
+        The parent schedule.
+    subgraphs : List[List[Tuple[Node, Node]]]
+        The fused subgraphs that need to be transferred hooks.
+    new_mod : torch.nn.Module
+        The new module that will be created after fusion.
+    """
+    hook_types = HOOK_TYPE_TO_ATTR.keys()
+    if len(subgraphs) > 1:
+        # Since horizontal fusion needs to combine the hooks together,
+        # we cannot support it for now.
+        for i, sublst in enumerate(subgraphs):
+            for _, node in sublst:
+                if node.op != "call_module":
+                    break
+                old_mod = sch.get_module(node.target)
+                for hook in hook_types:
+                    if has_hook(old_mod, hook) > 0:
+                        raise RuntimeError(
+                            f"Cannot use horizontal fusion since module {node.target} has a {hook} hook"
+                        )
+    else:
+        ops = subgraphs[0]
+        for i, (_, node) in enumerate(ops):
+            if node.op == "call_module":
+                old_mod = sch.get_module(node.target)
+                if i == 0:  # the first node
+                    if has_hook(old_mod, "fwd_post"):
+                        raise RuntimeError(
+                            f"Cannot transfer hooks from {node.target} to the new module since {node.target} has a fwd_post hook"
+                        )
+                    transfer_hooks(old_mod, new_mod, ["fwd_pre", "bwd_post"])
+                elif i == len(ops) - 1:  # the last node
+                    if has_hook(old_mod, "fwd_pre") or has_hook(old_mod, "bwd_post"):
+                        raise RuntimeError(
+                            f"Cannot transfer hooks from {node.target} to the new module since {node.target} has a fwd_pre/bwd_post hook"
+                        )
+                    transfer_hooks(old_mod, new_mod, ["fwd_post"])
+                elif any(has_hook(old_mod, x) for x in hook_types):
+                    raise RuntimeError(
+                        f"Cannot transfer hooks from {node.target} to the new module since {node.target} is in the middle of the subgraph"
+                    )
+
+
 def is_lambda_function(obj):
     return isinstance(obj, FunctionType) and obj.__name__ == "<lambda>"
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Test replace primitives."""
-# pylint: disable=comparison-with-callable
+# pylint: disable=comparison-with-callable, unused-argument
 
 import operator
 import pytest
@@ -189,7 +189,6 @@ def test_replace_function():
 
 def test_transfer_hook():
     """Test whether the hooks are transferred to the new replaced module."""
-    # pylint: disable=unused-argument
 
     class Model(nn.Module):
         def __init__(self):

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Test replace primitives."""
-import pytest
+# pylint: disable=comparison-with-callable
 
 import operator
+import pytest
+
 from torch import nn
 import torch.nn.functional as F
 
@@ -58,9 +60,6 @@ def test_vertical_replacement():
     assert len(subgraph[0]) == 2
 
     class Identity(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-
         def forward(self, x):
             return x
 
@@ -106,9 +105,6 @@ def test_horizontal_replacement():
     assert subgraph[0][1][1].target == "permute"
 
     class Identity(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-
         def forward(self, x):
             return (x, x)
 

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -144,6 +144,20 @@ def test_horizontal_replacement():
             cnt += 1
     assert cnt == 2
 
+    # test invalid hooks
+    attn = CoreAttention()
+    sch = slapo.create_schedule(attn)
+
+    def fwd_pre_hook(mod, inp):
+        return inp
+
+    # Directly register hooks instead of using .sync, because
+    # we do not want to test .sync in this test.
+    sch.mod.fc1.register_forward_pre_hook(fwd_pre_hook)
+    subgraph = sch.find(pattern)
+    with pytest.raises(Exception):
+        sch.replace(mod, subgraph)
+
 
 def test_replace_function():
     class Model(nn.Module):


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR creates subschedule for replaced subgraph module (vertical & horizontal fusion) and attach hooks to the new module. Previously, we only create subschedule for single module replacement. Also, the `replace_function` API is changed, accepting a tuple `(str, fx.Node)` instead of a single node, in order to match the API of `replace_module`. Corresponding tests are also added to ensure correctness.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

