### PR TITLE
[Bugfix] Support tree-like subgraph matching

### DIFF
--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -906,6 +906,7 @@ class SubgraphWrapper(nn.Module):
                         k
                         for k, v in sig.parameters.items()
                         if v.default is inspect.Parameter.empty
+                        and v.kind is not inspect.Parameter.VAR_POSITIONAL
                     ]
                     default_args = {
                         k: v.default

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -916,6 +916,8 @@ class SubgraphWrapper(nn.Module):
                             new_kwargs[key] = value
                     if concrete_args is not None:
                         new_kwargs.update(concrete_args)
+                    else:
+                        concrete_args = {}
                     subgraph_args = []
                     for node in ops:
                         for arg in node.args:

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -816,6 +816,8 @@ class SubgraphWrapper(nn.Module):
         name : Optional[str]
             The name of the replaced module. If it is None, a default name
             will be automatically generated.
+        concrete_args : Optional[Dict[str, Any]]
+            The concrete arguments of the forward function of the new module.
         """
         if subgraphs is None:
             if name is not None and name != self.name:

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -194,6 +194,29 @@ def test_two_paths():
     assert subgraph[1][1].target == "relu"
 
 
+def test_tree_pattern():
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y, z):
+            a = x + y
+            b = y - z
+            c = a * b
+            return c
+
+    sch = slapo.create_schedule(Model())
+
+    def pattern(x, y, z):
+        return (x + y) * (y - z)
+
+    subgraph = sch.find(pattern)[0]
+    assert len(subgraph) == 3
+    assert subgraph[0][1].name == "add"
+    assert subgraph[1][1].name == "sub"
+    assert subgraph[2][1].name == "mul"
+
+
 def test_horizontal_pattern():
     class CoreAttention(nn.Module):
         def __init__(self):

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -196,9 +196,6 @@ def test_two_paths():
 
 def test_tree_pattern():
     class Model(nn.Module):
-        def __init__(self):
-            super().__init__()
-
         def forward(self, x, y, z):
             a = x + y
             b = y - z


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
For the following tree-like subgraph with multiple inputs, if we use the `pattern` to match the `+`, `-`, and `*` operators, only `+` and `*` will be returned. This is because the current implementation of subgraph matching starts from the first instruction of the original subgraph and target subgraph, and test if **users** of the instruction are the same. The process is iterative and basically is a DFS. However, this process may ignore instruction `b` since `b` is not the user of `a`.

```python
class Model(nn.Module):
    def forward(self, x, y, z):
        a = x + y
        b = y - z
        c = a * b
        return c
```
```python
def pattern(x, y, z):
    return (x + y) * (y - z)
```

To solve this problem, we can simply traverse the graph node from top to bottom following the order of the link list (i.e., visiting the **successors** in a topological order), and compare the nodes in the original and target subgraph, so that all the `+`, `-`, and `*` operators will be matched. Notice this fix still cannot support commutativity between operands, so pattern `(y - z) * (x + y)` cannot match any subgraphs. This feature may need more engineering efforts in the future.

Also, this PR adds `concrete_args` to `.replace_module()` for the case that the user-defined module has different numbers of arguments with the arguments in the original subgraph.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

