### PR TITLE
Enable launch training with torchrun

### DIFF
--- a/examples/gpt2/deepspeed_hf.py
+++ b/examples/gpt2/deepspeed_hf.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import argparse
 
 import deepspeed
@@ -337,6 +338,8 @@ if __name__ == "__main__":
         help="bf16 is enabled",
     )
     args = parser.parse_args()
+    if os.environ.get("LOCAL_RANK"):
+        args.local_rank = int(os.environ["LOCAL_RANK"])
 
     if args.fp16 and args.bf16:
         raise ValueError(

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -35,6 +35,7 @@ def get_ds_config(
         "pipeline": {
             "sequence_parallel": sequence_parallel,
         },
+        "wall_clock_breakdown": False,
     }
 
     if zero_stage > 0:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
`torchrun` does not inject the `local_rank` via command arguement `--local_rank`. Instead reading from the environment variable `LOCAL_RANK`. 
The modification allows following launch command, which does not require a `hostfile`. 
```
torchrun --master_port $MASTER_PORT \
          --master_addr $JOB_NAME-master-0 \
          --nnodes $WORLD_SIZE \
          --nproc_per_node 8 \
          --node_rank $RANK \
          /mnt/zhzhn/slapo/examples/gpt2/deepspeed_hf.py \
          --tmp 4 --pmp 2 --hidden-size 2048 --nlayers 12 \
          --num-attn-heads 16 
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

