### PR TITLE
[Refactor] Schedule primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We provide the following primitives for dynamic graph optimizations:
 | :--: | :-- |
 | Module replacement | `s[op].replace(new_module)` |
 | Tensor parallelism | `s[op].shard(param_name, axis)` |
-| Synchronization | `s[op].sync(mode="forward/backward/both", sync_op_or_fn, **kwargs)` |
+| Synchronization | `s[op].sync(mode="fwd_pre/fwd_post/bwd_post", sync_op_or_fn, **kwargs)` |
 | Checkpointing | `s[op].checkpoint()` |
 
 And the following primitives for static graph optimizations:
@@ -90,10 +90,24 @@ And the following primitives for static graph optimizations:
 | Module Tracing | `s.trace(leaves, flatten)` |
 | Pattern matching | `s.find(regex_or_pattern_fn)` |
 | Operator fusion | `s[op].fuse(compiler, subgraph)` |
+| Layer decomposition | `s[op].decompose()` |
 | Partial module replacement | `s[op].replace(new_module, subgraph)` |
 | Partial gradient checkpointing | `s[op].checkpoint(subgraph)` |
-| Pipeline parallelism | `s[op].pipeline_split()` |
+| Pipeline parallelism | `s[op].cut_pipeline_stage()` |
 
+You can look for all supported primitvies with the following API:
+
+```python
+import slapo
+print(slapo.list_primitives())
+```
+
+You could also check the description of each primitive on the fly:
+
+```python
+import slapo
+print(slapo.desc_primitive("shard"))
+```
 
 ### Auto-Tuning
 We also provide a light-weight interface for auto-tuning, so the developers can (1) construct a polyhedral search space using our APIs, and (2) leverage Slapo auto-tuner to automatically search for the best training configuration.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You could also check the description of each primitive on the fly:
 
 ```python
 import slapo
-print(slapo.desc_primitive("shard"))
+help(slapo.list_primitives(name_only=False)["shard"])
 ```
 
 ### Auto-Tuning

--- a/slapo/__init__.py
+++ b/slapo/__init__.py
@@ -5,6 +5,8 @@ from .autotune.tune import Database, Space, Symbol
 from .env import *
 from .initialization import init_empty_weights
 from .logger import get_logger
+from .primitives import register_primitive
+from .build import *
 from .schedule import *
 from .tracer import *
 from .utils import *

--- a/slapo/build.py
+++ b/slapo/build.py
@@ -1,0 +1,247 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Functions to build the model based on the schedule."""
+from __future__ import annotations
+
+import gc
+from collections.abc import Callable
+from typing import Optional, Union
+
+import torch
+from torch import distributed as dist
+from torch import nn
+
+from .framework_dialect import get_dialect_cls
+from .logger import get_logger
+from .pipeline import (
+    analyze_tie_weights,
+    build_pipeline_model,
+    generate_pipeline_partition,
+)
+from .schedule import Schedule
+
+logger = get_logger()
+
+
+def consolidate_model(
+    sch: Schedule,
+    target: str,
+    param_init_fn: Optional[Callable[[nn.Module], None]] = None,
+    **kwargs,
+):
+    """Consolidate the model weights.
+    FIXME: When pipeline is enabled, this function only supports DeepSpeed
+    runtime because it relies on DeepSpeed topology. We should use dialects
+    in this function to make it general applicable.
+    """
+    topology = kwargs.get("topology", None)
+    if dist.is_initialized() and dist.get_world_size() > sch.world_size:
+        if topology is None:
+            raise ValueError(
+                "topology must be given when there are multiple "
+                "tensor paralel groups or pipeline parallelism is used"
+            )
+        if target != "deepspeed":
+            raise ValueError(
+                "Only deepspeed runtime is supported for now when there are multiple "
+                "tensor paralel groups or pipeline parallelism is used"
+            )
+
+    cnt_meta, cnt_materialized = 0, 0
+    # Since some parameters are attached to non-leaf modules, we need to
+    # fix them layer-by-layer. See the following example:
+    # https://github.com/huggingface/transformers/blob/v4.25.1/src/transformers/models/bert/modeling_bert.py#L693
+    for _, param in sch.mod.named_parameters(recurse=True):
+        if param.device == torch.device("meta"):
+            cnt_meta += 1
+        else:
+            cnt_materialized += 1
+
+    stage_groups = None
+    # local rank means the rank in a node
+    local_rank = torch.cuda.current_device()
+    global_rank = None
+    global_ranks = [None]
+    if cnt_meta != 0 or cnt_materialized != 0:
+        if dist.is_initialized():
+            # Tackle with pipeline modules.
+            # Even the model does not use meta device, we still need to broadcast
+            # the weights to ensure consistency
+            global_rank = dist.get_rank()
+            if topology is not None:
+                # 1st DP: devices in the same bracket are in the same TP group
+                #         vertical lines separate different PP stages
+                # [0, 1] |
+                #        | [4, 5]
+                # 2nd DP
+                # [2, 3] |
+                #        | [6, 7]
+                # >>> topo = PipeModelDataParallelTopology(2, 2, 2)
+                # >>> topo.get_axis_comm_lists("model")
+                # [[0, 1], [2, 3], [4, 5], [6, 7]]
+                # >>> topo.get_axis_comm_lists("pipe")
+                # [[0, 4], [1, 5], [2, 6], [3, 7]]
+                # >>> topo.get_axis_comm_lists("data")
+                # [[0, 2], [1, 3], [4, 6], [5, 7]]
+                # >>> topo.filter_match(pipe=0)
+                # [0, 1, 2, 3]
+                # create dist group for broadcasting
+                num_pp = topology.get_dim("pipe")
+                # each group contains the devices on the same stage
+                stage_groups = []
+                for i in range(num_pp):
+                    stage_groups.append(
+                        dist.new_group(ranks=topology.filter_match(pipe=i))
+                    )
+            else:
+                stage_groups = [dist.new_group()]
+
+            global_ranks = list(range(dist.get_world_size()))
+    else:
+        return sch
+
+    def _init_module(sch: Schedule):
+        if param_init_fn:
+            param_init_fn(sch.mod)
+        elif hasattr(sch.mod, "_init_weights"):
+            # `_init_weights` is a HF specific API, see
+            # https://github.com/huggingface/transformers/blob/v4.25.1/src/transformers/models/bert/modeling_bert.py#L748
+            sch.mod._init_weights(sch.mod)
+        elif hasattr(sch.mod, "reset_parameters"):
+            sch.mod.reset_parameters()
+        else:
+            raise RuntimeError(
+                f"Module {sch.name} should have `reset_parameters` or "
+                "`_init_weights` method or param_init_fn={param_init_fn} needs "
+                "to be provided in order to support delay initialization"
+            )
+
+    def _consolidate_and_broadcast(sch: Schedule):
+        if isinstance(sch.mod, torch.jit.ScriptModule):
+            # Scripted module requires the parameters to be initialized in advance,
+            # so no need to consolidate
+            return 0, 0
+
+        if hasattr(sch, "partition_idx") and topology is not None:
+            curr_part_idx = sch.partition_idx
+            # topology stores the global ranks
+            curr_stage_devices = topology.filter_match(pipe=curr_part_idx)
+        else:
+            curr_part_idx = 0
+            curr_stage_devices = global_ranks
+
+        if global_rank not in curr_stage_devices:
+            # do nothing if the target module is NOT on this device group
+            return 0, 0
+
+        # Register parameters with the original shape (if sharded) for initialization.
+        num_params = 0
+        new_param_shapes = {}
+        for param_name, param in sch.mod.named_parameters(recurse=False):
+            num_params += 1
+            new_param_shapes[param_name] = param.shape
+            orig_shape = (
+                param.orig_shape if hasattr(param, "orig_shape") else param.shape
+            )
+            new_param = nn.Parameter(
+                torch.empty(orig_shape, dtype=param.dtype, device=local_rank)
+            )
+            sch.mod.register_parameter(
+                param_name,
+                new_param,
+            )
+            if hasattr(param, "replicated_param") and param.replicated_param:
+                new_param.replicated_param = True
+
+        # Use original shape to initialize parameters.
+        if global_rank == curr_stage_devices[0] and num_params > 0:
+            # only the first device in the PP group needs to initialize the weights
+            _init_module(sch)
+
+        # Broadcast complete params from rank 0 to make sure all the TP+DP ranks
+        # take the same params.
+        if dist.is_initialized():
+            curr_stage_group = stage_groups[curr_part_idx]
+            for _, param in sch.mod.named_parameters(recurse=False):
+                dist.broadcast(param, src=curr_stage_devices[0], group=curr_stage_group)
+
+        # Only keep the partition for this device for sharded params.
+        tp_rank = sch.rank
+        cnt_shard = 0
+        for param_name, param in sch.mod.named_parameters(recurse=False):
+            is_found = False
+            for idx, new_size in enumerate(new_param_shapes[param_name]):
+                if new_size != param.shape[idx]:
+                    assert not is_found, "Cannot have two sharded dimensions!"
+                    sharded_size = new_size
+                    axis = idx
+                    is_found = True
+            if is_found:
+                cnt_shard += 1
+                sharded_param = param.detach().split(sharded_size, dim=axis)[tp_rank]
+                sharded_param = sharded_param.contiguous()
+                new_param = nn.Parameter(sharded_param)
+                new_param.tensor_model_parallel = True
+                sch.mod.register_parameter(param_name, new_param)
+
+        for subsch in sch.child.values():
+            ret = _consolidate_and_broadcast(subsch)
+            num_params += ret[0]
+            cnt_shard += ret[1]
+
+        return num_params, cnt_shard
+
+    if cnt_meta != 0 or cnt_materialized != 0:
+        num_params, cnt_shard = _consolidate_and_broadcast(sch)
+
+    logger.info(
+        "Finished consolidating %d parameter tensors with %d being sharded",
+        num_params,
+        cnt_shard,
+    )
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return sch
+
+
+def init_target_engine(sch, target, **kwargs):
+    """Initialize the runtime engine for a specific target framework."""
+    init_engine_fn = get_dialect_cls("runtime_engine", target, allow_none=True)
+    return init_engine_fn(
+        sch,
+        **kwargs,
+    )
+
+
+def build(
+    sch: Schedule,
+    target=None,
+    init_weights: Optional[Union[bool, Callable]] = True,
+    **kwargs,
+):
+    if sch.metadata.primitives["cut_pipeline_stage"]:
+        # pipeline stages will be wrapped into PipeStageWrapper
+        sch = generate_pipeline_partition(sch)
+        # Re-analyzie tie weights before consolidation.
+        sch.metadata.tie_weights = analyze_tie_weights(
+            sch.mod, is_pipeline_partitioned=True
+        )
+
+    # delay initialization
+    if init_weights:
+        init_weight_fn = init_weights if isinstance(init_weights, Callable) else None
+        sch = consolidate_model(sch, target, init_weight_fn, **kwargs)
+
+    if sch.metadata.primitives["cut_pipeline_stage"] and target is not None:
+        # Generate pipeline modules for a particular target.
+        model = build_pipeline_model(
+            sch,
+            target,
+            **kwargs,
+        )
+    else:
+        model = sch.mod
+
+    return init_target_engine(model, target, **kwargs)

--- a/slapo/op/__init__.py
+++ b/slapo/op/__init__.py
@@ -5,5 +5,5 @@ from .attention import FlashAttention, FlashAttentionOp, AttentionOpWithRNG
 from .bias_gelu import FusedBiasGELU, FusedBiasNewGELU
 from .cross_entropy import ParallelCrossEntropy
 from .dropout import DropoutWithTensorParallel
-from .linear import FusedQKV
+from .linear import FusedQKV, LinearWithSeparateBias
 from .mlp import FusedMLP

--- a/slapo/pipeline.py
+++ b/slapo/pipeline.py
@@ -368,8 +368,10 @@ def analyze_tie_weights(top_mod, is_pipeline_partitioned):
 def generate_pipeline_partition(sch):
     # Identify the common ancestor of all pipeline cutting paths.
     common_ancestor_path = ""
-    if len(sch.metadata.pipeline_cutting_paths) > 1:
-        path_tokens = [path.split(".") for path in sch.metadata.pipeline_cutting_paths]
+    if len(sch.metadata.primitives["cut_pipeline_stage"]) > 1:
+        path_tokens = [
+            path.split(".") for path in sch.metadata.primitives["cut_pipeline_stage"]
+        ]
         for tokens in zip(*path_tokens):
             if len(list(set(tokens))) != 1:
                 break
@@ -379,8 +381,8 @@ def generate_pipeline_partition(sch):
 
     # Propogate pipeline partitioning from the cutting level to the common ancestor.
     starting_stage_id = 0
-    assert sch.metadata.pipeline_cutting_paths
-    for path in sch.metadata.pipeline_cutting_paths:
+    assert sch.metadata.primitives["cut_pipeline_stage"]
+    for path in sch.metadata.primitives["cut_pipeline_stage"]:
         if path == common_ancestor_path:
             # Skip the common ancestor because it should be handled in the next step.
             continue

--- a/slapo/primitives/__init__.py
+++ b/slapo/primitives/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Schedule primitives."""
+
+import os
+from os.path import abspath, dirname, join, isfile
+from inspect import getsourcefile, getmembers
+from importlib import import_module
+
+from .base import register_primitive, PRIMITIVES, Primitive
+
+path = dirname(abspath(getsourcefile(lambda: 0)))
+files = [
+    f
+    for f in os.listdir(path)
+    if isfile(join(path, f)) and f not in {"__init__.py", "base.py"}
+]
+for file in files:
+    mod = import_module(f".{file.split('.')[0]}", package="slapo.primitives")
+    # register the schedule primitive using the decorator
+    getmembers(mod)

--- a/slapo/primitives/base.py
+++ b/slapo/primitives/base.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Schedule primitive base."""
+from __future__ import annotations
+from abc import abstractmethod
+
+PRIMITIVES = {}
+
+
+def register_primitive():
+    """Register a primitive to the schedule."""
+
+    def dectorator(cls):
+
+        if cls.name() in PRIMITIVES:
+            raise ValueError(f"Primitive {cls.name()} already registered")
+        PRIMITIVES[cls.name()] = cls
+        return cls
+
+    return dectorator
+
+
+class Primitive:
+    """A base class of schedule primitives."""
+
+    @staticmethod
+    @abstractmethod
+    def name():
+        """The name of the primitive."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def apply(sch, *args, **kwargs):
+        """Apply the primitive to the schedule."""
+        raise NotImplementedError
+
+    @staticmethod
+    def init_metadata():
+        """(Optional) Initialize the metadata of the primitive."""
+        return None

--- a/slapo/primitives/base.py
+++ b/slapo/primitives/base.py
@@ -14,6 +14,8 @@ def register_primitive():
 
         if cls.name() in PRIMITIVES:
             raise ValueError(f"Primitive {cls.name()} already registered")
+        if not issubclass(cls, Primitive):
+            raise ValueError(f"Class {cls} is not a subclass of Primitive")
         PRIMITIVES[cls.name()] = cls
         return cls
 

--- a/slapo/primitives/checkpoint.py
+++ b/slapo/primitives/checkpoint.py
@@ -19,6 +19,8 @@ class CheckpointPrimitive(Primitive):
         The subgraph to be checkpointed. If None, checkpoint the entire module.
     order_args_fn : Optional[Callable]
         A function to order the position and keyword arguments of the module.
+        The function should take the same arguments as the module forward function,
+        and return a list or tuple of the ordered arguments.
         If None, the arguments will be ordered by the order of the position arguments,
         followed by the key order of the keyword arguments.
     """

--- a/slapo/primitives/checkpoint.py
+++ b/slapo/primitives/checkpoint.py
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Checkpoint primitive."""
+# pylint: disable=arguments-differ
+
+from torch import nn
+
+from .base import register_primitive, Primitive
+from ..checkpoint import checkpoint as checkpoint_module
+
+
+@register_primitive()
+class CheckpointPrimitive(Primitive):
+    """Add activation checkpointing to the entire module or a subgraph.
+
+    Parameters
+    ----------
+    subgraph : Optional[List[List[torch.fx.Node]]]
+        The subgraph to be checkpointed. If None, checkpoint the entire module.
+    order_args_fn : Optional[Callable]
+        A function to order the position and keyword arguments of the module.
+        If None, the arguments will be ordered by the order of the position arguments,
+        followed by the key order of the keyword arguments.
+    """
+
+    @staticmethod
+    def name():
+        return "checkpoint"
+
+    @staticmethod
+    def apply(sch, subgraph=None, order_args_fn=None):
+        class CheckPointWrapper(nn.Module):
+            def __init__(self, mod) -> None:
+                super().__init__()
+                self.mod = mod
+
+            def forward(self, *args, **kwargs):
+                ordered_args = []
+                if order_args_fn is None:
+                    ordered_args = list(args)
+                    for value in kwargs.values():
+                        ordered_args += [value]
+                else:
+                    ordered_args = order_args_fn(*args, **kwargs)
+
+                # Note: checkpoint cannot accept kwargs
+                return checkpoint_module(self.mod, *ordered_args)
+
+        if subgraph is None:
+            # Checkpoint the entire module.
+            sch.replace(CheckPointWrapper(sch.mod))
+        else:
+            # Checkpoint the subgraph
+            new_gm = sch._construct_fx_graph(subgraph[0])
+            sch.replace(CheckPointWrapper(new_gm), subgraph)

--- a/slapo/primitives/fusion.py
+++ b/slapo/primitives/fusion.py
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fusion related primitives."""
+# pylint: disable=arguments-differ
+
+import torch
+from torch import nn
+
+from .base import register_primitive, Primitive
+from ..initialization import init_empty_weights
+from ..op import LinearWithSeparateBias
+
+
+@register_primitive()
+class FusePrimitive(Primitive):
+    """Fuse a subgraph into a single module using a backend compiler.
+
+    Parameters
+    ----------
+    subgraph : List[List[torch.fx.Node]]
+        The subgraph to be fused.
+    compiler : str
+        The backend compiler to be used. Currently only support "TorchScript".
+    name : str
+        The name of the fused module.
+    """
+
+    @staticmethod
+    def name():
+        return "fuse"
+
+    @staticmethod
+    def apply(sch, subgraph, compiler="TorchScript", name="FusedModule"):
+        assert (
+            compiler == "TorchScript"
+        ), "Only support TorchScript as the backend compiler for now"
+        assert (
+            len(subgraph) == 1 and len(subgraph[0]) > 1
+        ), "Only vertical fusion is supported"
+        new_gm = sch._construct_fx_graph(subgraph[0])
+        new_mod = torch.jit.script(new_gm)
+        sch.replace(new_mod, subgraph, name)
+
+
+@register_primitive()
+class DecomposePrimitive(Primitive):
+    """Decompose a module. Currently only support decomposing a linear layer.
+    Specifically, this primitive replaces a linear layer with LinearWithSeparateBias,
+    which computes the bias separately from the weight. This is useful when we want
+    to fuse the bias addition into the following logic (e.g., activation function).
+
+    Parameters
+    ----------
+    mod : torch.nn.Module
+        The module to be decomposed.
+    """
+
+    @staticmethod
+    def name():
+        return "decompose"
+
+    @staticmethod
+    def apply(sch):
+        if not isinstance(sch.mod, nn.Linear):
+            raise RuntimeError(
+                "Can only support decomposing a `nn.Linear` layer for now"
+            )
+        if (
+            sch.mod.weight.shape[1] != sch.mod.in_features
+            or sch.mod.weight.shape[0] != sch.mod.out_features
+        ):
+            raise RuntimeError(".shard() should be applied after .decompose()")
+        # Replace the linear module
+        with init_empty_weights(enable=(sch.mod.weight.device == torch.device("meta"))):
+            new_mod = LinearWithSeparateBias(
+                sch.mod.weight.shape[1],
+                sch.mod.weight.shape[0],
+                device=sch.mod.weight.device,
+                dtype=sch.mod.weight.dtype,
+            )
+            # Use original value
+            new_mod.weight = sch.mod.weight
+            new_mod.bias = sch.mod.bias
+            sch.replace(new_mod)

--- a/slapo/primitives/pipeline.py
+++ b/slapo/primitives/pipeline.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline related primitives."""
+# pylint: disable=arguments-differ
+
+from collections import OrderedDict
+
+from torch import fx
+
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class CutPipelineStagePrimitive(Primitive):
+    """Cut pipeline stage. This primitive is used to cut the pipeline stage.
+    Taking a model with 24 layers as an example, the following code will cut
+    the model into 4 stages with 6 layers each (inclusive).
+
+    sch["layers.3].cut_pipeline_stage()
+    sch["layers.9].cut_pipeline_stage()
+    sch["layers.15].cut_pipeline_stage()
+
+    Note that this primitive comes with a metadata that records the cutting
+    points, which will be used by slapo.build to construct the pipeline.
+    """
+
+    @staticmethod
+    def name():
+        return "cut_pipeline_stage"
+
+    @staticmethod
+    def apply(sch):
+        primitive_name = CutPipelineStagePrimitive.name()
+        parent_sch = sch.parent
+
+        # Sanity check.
+        if not parent_sch:
+            raise ValueError("Cannot cut the top module")
+        if not isinstance(parent_sch.mod, fx.GraphModule):
+            raise RuntimeError(
+                "Parent module has not been traced. "
+                "Please use 'trace_for_pipeline' to trace until "
+                "the level you want to cut pipeline stages."
+            )
+
+        # Find the corresponding call node in the parent module
+        # and annotate it with pipeline partition.
+        for node in parent_sch.mod.graph.nodes:
+            if node.op == "call_module" and node.target == sch.name:
+                node.meta["partition"] = True
+
+        # Propogate the pipeline cutting level to the root.
+        root_sch = parent_sch
+        while root_sch is not None:
+            root_sch.metadata.primitives[primitive_name][parent_sch.path] = True
+            root_sch = root_sch.parent
+
+    @staticmethod
+    def init_metadata():
+        """A set of paths to the modules that includes pipeline cutting annotations.
+        Note that we use ordered set to keep the order of the modules.
+        """
+        return OrderedDict()

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -1,0 +1,282 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Replace primitive."""
+# pylint: disable=arguments-differ
+
+import inspect
+import operator
+
+from types import FunctionType
+
+from torch import fx
+
+from ..logger import get_logger
+from ..utils.common import transfer_hooks, transfer_hooks_for_fusion
+from ..schedule import create_schedule
+from .base import Primitive, register_primitive
+
+logger = get_logger()
+
+
+def _get_unique_module_name(gm_or_modules, name):
+    """Get the unique name for a module in the graph.
+
+    Parameters
+    ----------
+    gm_or_modules : Optional[GraphModule, Dict[str, torch.nn.Module]]
+        The graph module or the named modules in the graph.
+    name : str
+        The name of the module.
+
+    Returns
+    -------
+    str
+        The unique name for the module.
+    """
+    if isinstance(gm_or_modules, fx.GraphModule):
+        named_module = dict(gm_or_modules.named_modules())
+    else:
+        named_module = gm_or_modules
+    num = 1
+    new_name = name + "_0"
+    while new_name in named_module.keys():
+        new_name = name + "_" + str(num)
+        num += 1
+    return new_name
+
+
+def _replace_function(sch, func, target_op):
+    """Replace a function, in terms of a call_function node in fx graph.
+    Do NOT directly call this function, use `.replace()` instead
+
+    Parameters
+    ----------
+    sch : Schedule
+        The schedule with the function to be replaced.
+    func : Callable
+        The new function to replace the current function.
+    target_op : List[Tuple[str, torch.fx.Node]]
+        The call_function node to be replaced.
+        The string in the tuple is the name of the parent module that
+        the node belongs to.
+    """
+    _, node = target_op
+    with sch.mod.graph.inserting_after(node):
+        new_node = sch.mod.graph.call_function(func, node.args, node.kwargs)
+        node.replace_all_uses_with(new_node)
+    sch.mod.graph.erase_node(node)
+
+
+def _replace_module(self_sch, new_mod, subgraphs=None, name=None, concrete_args=None):
+    """Replace an entire module with a new one.
+    Do NOT directly call this function, use `.replace()` instead.
+    If subgraphs is None, replace the whole self_sch module;
+    Otherwise, replace target forward subgraphs with the new module.
+    Parameters
+    ----------
+    self_sch : Schedule
+        The schedule with the module to be replaced.
+    new_mod : torch.nn.Module
+        The new module to replace the current module.
+    subgraphs : Optional[List[Tuple[str, torch.fx.Node]]]
+        The list of subgraphs to replace. Each subgraph is a tuple of
+        (module_name, node). If it is None, replace the whole module.
+    name : Optional[str]
+        The name of the replaced module. If it is None, a default name
+        will be automatically generated.
+    concrete_args : Optional[Dict[str, Any]]
+        The concrete arguments of the forward function of the new module.
+    """
+    if subgraphs is None:
+        if name is not None and name != self_sch.name:
+            logger.warning(
+                "Cannot change the name of %s when replacing the whole module. "
+                "The given name %s will be ignored",
+                self_sch.name,
+                name,
+            )
+        name = self_sch.name
+    else:
+        if name is None:
+            name = new_mod._get_name().split(".")[-1]
+        name = _get_unique_module_name(self_sch.mod, name)
+    # Create a new schedule for the replaced module
+    new_sch = create_schedule(
+        new_mod, name, self_sch.path, self_sch.parent, self_sch.group
+    )
+    # Replace the corresponding part in the current module
+    if subgraphs is None:
+        # If subgraphs is None, replace the whole self_sch module.
+        # Transfer hooks from the old module to the new module.
+        transfer_hooks(self_sch.mod, new_sch.mod)
+        # Update schedules
+        self_sch.mod = new_sch.mod
+        self_sch.child = new_sch.child
+        for _, sch in self_sch.child.items():
+            sch.parent = self_sch
+        if self_sch.parent:
+            self_sch.update_submodule(self_sch.parent.mod, self_sch.name, new_mod)
+    else:
+        # Replacing target forward subgraphs with the new module
+        # requires the current module in torch.fx so it has to be traced.
+        self_sch.trace()
+        assert len(subgraphs) > 0, "Should have at least one operator to replace"
+        if len(subgraphs) > 1:
+            # horizontal fusion, e.g.,
+            #     x
+            #   / | \
+            #  s0 s1 s2
+            #  v0 v1 v2
+            #  [[s0, v0], [s1, v1], [s2, v2]]
+            path, node = subgraphs[0][0]
+            target_mod = self_sch.mod
+            if path:
+                assert hasattr(
+                    self_sch.mod, path
+                ), f"{path} is not an attribute of {self_sch.mod}"
+                target_mod = getattr(self_sch.mod, path)
+
+            target_mod.add_module(name, new_mod)
+            # TODO: Need to handle the case where the replaced module
+            # has different numbers of arguments with the original module.
+            # Also need more tests.
+            with target_mod.graph.inserting_before(node):
+                new_node = target_mod.graph.call_module(name, node.args, node.kwargs)
+            with target_mod.graph.inserting_after(new_node):
+                for i, sublst in enumerate(subgraphs):
+                    getitem = target_mod.graph.call_function(
+                        operator.getitem, (new_node, i)
+                    )
+                    sublst = [sublst] if not isinstance(sublst, list) else sublst
+                    for _, node in reversed(sublst):
+                        if node.users not in sublst:
+                            node.replace_all_uses_with(getitem)
+                        target_mod.graph.erase_node(node)
+            transfer_hooks_for_fusion(self_sch, subgraphs, new_mod)
+        else:
+            # vertical fusion, e.g.,
+            # s0->v0
+            # [[s0, v0]]
+            ops = subgraphs[0]
+            path, first_node = ops[0]
+            ops = [op[1] for op in ops]
+            target_mod = self_sch.mod
+            if path:
+                assert hasattr(
+                    self_sch.mod, path
+                ), f"{path} is not an attribute of {self_sch.mod}"
+                target_mod = getattr(self_sch.mod, path)
+
+            target_mod.add_module(name, new_mod)
+            with target_mod.graph.inserting_before(first_node):
+                sig = inspect.signature(new_mod.forward)
+                mod_args_need_inputs = [
+                    k
+                    for k, v in sig.parameters.items()
+                    if v.default is inspect.Parameter.empty
+                    and v.kind is not inspect.Parameter.VAR_POSITIONAL
+                ]
+                default_args = {
+                    k: v.default
+                    for k, v in sig.parameters.items()
+                    if v.default is not inspect.Parameter.empty
+                }
+                new_kwargs = {}
+                for key, value in default_args:
+                    if key in first_node.kwargs:
+                        new_kwargs[key] = value
+                if concrete_args is not None:
+                    new_kwargs.update(concrete_args)
+                else:
+                    concrete_args = {}
+                subgraph_args = []
+                for node in ops:
+                    for arg in node.args:
+                        if (
+                            isinstance(arg, fx.Node)
+                            and arg not in ops
+                            and arg not in subgraph_args
+                        ):
+                            subgraph_args.append(arg)
+                if len(subgraph_args) + len(concrete_args) != len(mod_args_need_inputs):
+                    raise ValueError(
+                        "The number of arguments (w/o default values) of the "
+                        f"new module ({len(mod_args_need_inputs)}) does not match "
+                        "the number of arguments of the original subgraph "
+                        f"({len(subgraph_args)}). Please use `concrete_args` to "
+                        "specify the arguments."
+                    )
+                new_node = target_mod.graph.call_module(
+                    name, tuple(subgraph_args), new_kwargs
+                )
+            last_node = ops[-1]
+            last_node.replace_all_uses_with(new_node)
+            for node in reversed(ops):
+                target_mod.graph.erase_node(node)
+            transfer_hooks_for_fusion(self_sch, subgraphs, new_mod)
+        # Update schedules
+        self_sch.child[name] = new_sch
+
+
+@register_primitive()
+class ReplacePrimitive(Primitive):
+    """Replace one of the following scenarios:
+    1. Replace an entire module (new_mod_or_func is the new module object, target_ops=None).
+    2. Replace a part of the forward function (target_ops) with a new module or function.
+
+    Parameters
+    ----------
+    sch : Schedule
+        The schedule with the module/function to be replaced.
+    new_mod_or_func : Union[nn.Module, FunctionType]
+        The new module or function to replace the target module or function.
+    target_ops : Optional[List[Node]]
+        The target nodes to be replaced. If None, replace the entire module.
+    name : Optional[str]
+        The name of the new module. If None, use the name of the target module.
+    concrete_args : Optional[Dict[str, Any]]
+        The concrete arguments for the new module.
+    """
+
+    @staticmethod
+    def name():
+        return "replace"
+
+    @staticmethod
+    def apply(sch, new_mod_or_func, target_ops=None, name=None, concrete_args=None):
+        if isinstance(new_mod_or_func, FunctionType):
+            if isinstance(target_ops, list):
+                raise ValueError(
+                    "Cannot replace multiple nodes in forward with one function"
+                )
+            _replace_function(sch, new_mod_or_func, target_ops)
+        else:
+            _replace_module(sch, new_mod_or_func, target_ops, name, concrete_args)
+
+        # Clean up and update the schedule child list.
+        if isinstance(sch.mod, fx.GraphModule):
+            sch.mod.graph.eliminate_dead_code()
+            sch.mod.delete_all_unused_submodules()
+            sch.mod.graph.lint()
+            sch.mod.recompile()
+
+            # Remove OOD child.
+            named_children = [name for name, _ in sch.mod.named_children()]
+            to_be_removed = []
+            for child_name in sch.child:
+                if child_name not in named_children:
+                    to_be_removed.append(child_name)
+
+            for child_name in to_be_removed:
+                del sch.child[child_name]
+
+            # Add new child.
+            for child_name, submod in sch.mod.named_children():
+                if child_name not in sch.child:
+                    sch.child[child_name] = create_schedule(
+                        submod,
+                        child_name,
+                        f"{sch.path}.{child_name}",
+                        sch,
+                        sch.group,
+                    )

--- a/slapo/primitives/tensor_parallel.py
+++ b/slapo/primitives/tensor_parallel.py
@@ -1,0 +1,341 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor parallel primitives."""
+# pylint: disable=arguments-differ
+
+from collections import OrderedDict
+from functools import partial
+
+from torch import nn
+
+from ..sharding import (
+    all_gather_forward_output,
+    postproc_sharding,
+    reduce_backward_grad,
+    reduce_forward_output,
+    reduce_scatter_forward_output,
+    scatter_forward_output,
+)
+from .base import Primitive, register_primitive
+
+
+@register_primitive()
+class ShardPrimitive(Primitive):
+    """Shard a parameter along the given axis by the world size.
+    The shape of the parameter axis being sharded must be divisible by the world size.
+
+    Parameters
+    ----------
+    tensor_name: str
+        The name of the parameter to shard.
+    axis: int
+        The axis to shard on.
+    """
+
+    @staticmethod
+    def name():
+        return "shard"
+
+    @staticmethod
+    def apply(sch, tensor_name: str, axis: int):
+        def _shard(name, tensor):
+            assert axis < len(tensor.shape)
+            # TODO: Support arbitrary size sharding
+            if tensor.shape[axis] % sch.world_size != 0:
+                raise RuntimeError(
+                    f"Parameter/Buffer {name} in {sch.path} cannot be sharded "
+                    f"along axis {axis} with size {tensor.shape[axis]} "
+                    f"by {sch.world_size}"
+                )
+            sharded_size = tensor.shape[axis] // sch.world_size
+            return (
+                tensor.detach().split(sharded_size, dim=axis)[sch.rank].contiguous(),
+                sharded_size,
+            )
+
+        try:
+            param = sch.mod.get_parameter(tensor_name)
+            new_tensor, sharded_size = _shard(tensor_name, param)
+            if param in sch.metadata.tie_weights:
+                if id(sch.metadata.tie_weights[param]) != id(param):
+                    # This parameter is tied to another parameter, and the other
+                    # parameter is already sharded. In this case we directly
+                    # register the sharded parameter to the module to keep them tied.
+                    if new_tensor.shape != sch.metadata.tie_weights[param].shape:
+                        raise RuntimeError(
+                            f"Parameter {tensor_name} in {sch.path} is tied, "
+                            "but they have different sharded shapes: "
+                            f"{new_tensor.shape} vs "
+                            f"{sch.metadata.tie_weights[param].shape}"
+                        )
+                    new_param = sch.metadata.tie_weights[param]
+                else:
+                    # The first parameter in this tie group is sharded.
+                    new_param = nn.Parameter(new_tensor)
+                    sch.metadata.tie_weights[param] = new_param
+            else:
+                new_param = nn.Parameter(new_tensor)
+            # Tag param with model parallel attribute, used for grad clipping
+            new_param.tensor_model_parallel = True
+            # Save the original size of the parameter for consolidation.
+            new_param.orig_shape = param.shape
+            sch.mod.register_parameter(tensor_name, new_param)
+        except AttributeError:
+            buffer = sch.mod.get_buffer(tensor_name)
+            new_buffer, sharded_size = _shard(tensor_name, buffer)
+            sch.mod.register_buffer(tensor_name, new_buffer)
+
+        # Add metadata for sync and check. FIXME: A validation mechanism to check this.
+        # 1. Whether the param is already sharded in different axis.
+        # 2. Whether the output syncing method is conflict.
+        try:
+            sch.metadata.primitives["shard"][tensor_name] = axis
+        except KeyError:
+            raise RuntimeError(
+                f"Parameter/Buffer {tensor_name} in {sch.path} is already "
+                f"sharded along axis {sch.metadata.primitives['shard'][tensor_name]}"
+            ) from None
+
+        def set_output_type(output_type, gather_axis=None):
+            try:
+                sch.metadata.primitives["shard"]["output_type"] = output_type
+            except KeyError:
+                raise RuntimeError(
+                    f"Output type of {sch.path} is already "
+                    f"{sch.metadata.primitives['shard']['output_type']}, but "
+                    f"{output_type} is requested"
+                ) from None
+
+            if gather_axis is not None:
+                try:
+                    sch.metadata.primitives["shard"]["gather_axis"] = gather_axis
+                except KeyError:
+                    raise RuntimeError(
+                        f"Output of {sch.path} has to be gathered along axis "
+                        f"{sch.metadata.primitives['shard']['gather_axis']}, but "
+                        f"{gather_axis} is requested"
+                    ) from None
+
+        out_type, out_part_axis = postproc_sharding(
+            sch.mod, tensor_name, sharded_size, axis
+        )
+        if out_type is not None:
+            set_output_type(out_type, gather_axis=out_part_axis)
+
+    @staticmethod
+    def init_metadata():
+        return OrderedDict()
+
+
+def _validate_sync_op(sch, mode, sync_op_or_fn, axis=None):
+    """A helper function to validate the user given sync_op_or_fn."""
+    if mode == "fwd_post" and sync_op_or_fn == "scatter":
+        if "output_type" in sch.metadata.primitives["shard"]:
+            raise ValueError(
+                "Output of {sch.path} cannot be scatter along axis {axis}, "
+                "if its parameter is sharded"
+            )
+
+    if "output_type" not in sch.metadata.primitives["shard"]:
+        return
+    output_type = sch.metadata.primitives["shard"]["output_type"]
+
+    if mode == "fwd_post" and sync_op_or_fn == "all_gather":
+        if output_type == "partition":
+            gather_axis = sch.metadata.primitives["shard"]["gather_axis"]
+            if gather_axis != axis:
+                raise ValueError(
+                    f"Output of {sch.path} has to be gathered along axis "
+                    f"{gather_axis}, but {axis} is requested"
+                )
+        else:
+            raise ValueError("Cannot all-gather a full output")
+    elif mode == "fwd_post" and sync_op_or_fn == "reduce_scatter":
+        if output_type == "partition":
+            raise ValueError("Cannot reduce-scatter a partition output")
+    elif mode == "fwd_pre" and sync_op_or_fn == "all_gather":
+        if output_type == "partial":
+            raise ValueError(
+                "Cannot all-gather a partition input since the operator "
+                "with parameter sharded in the input dimension expects "
+                "partitioned input"
+            )
+    elif sync_op_or_fn == "all_reduce":
+        if mode == "fwd_post" and output_type == "partition":
+            raise ValueError("Cannot all-reduce a partition output")
+
+
+@register_primitive()
+class SyncPrimitive(Primitive):
+    """Synchronize the tensor across multiple devices.
+    Since the underlying implementation is registering a PyTorch hook
+    to the target module, the mode could be "fwd_pre", "fwd_post", "bwd_post".
+    The following are some example use cases:
+
+    Case 1: (replica x, shard_out w) -> partition output -> allgather
+            -> full output -> (replica x, shard_out w).
+        In this case, since forward uses all-gather to get a full output,
+        backward must have a split to match the shape, and
+        allreduce is also required for x.grad, so we use:
+        ```python
+        sch["out_prj"].shard("weight", axis=0)
+        sch["out_prj"].sync(mode="fwd_post", sync_op_or_fn="all_gather", axis=1)
+        sch["out_prj"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
+        ```
+
+    Case 2: (replica x, shard_out w) -> partition output -> (shard x, shard_in w).
+        In this case, backward still needs allreduce, so we use:
+        ```python
+        sch["out_prj"].shard("weight", axis=0)
+        sch["out_prj"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
+        ```
+
+    Case 3: (shard x, shard_in w) -> partial sum -> allreduce
+            -> (replica x, shard_out w).
+        In this case, backward does not need allreduce, so mode should be 'forward'.
+        ```python
+        sch["out_prj"].shard("weight", axis=1)
+        sch["out_prj"].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
+        ```
+
+    Case 4: (shard x, shard_in w) -> partial sum -> reduce-scatter
+            -> ... -> allgather -> full output.
+        This case breaks the allreduce in case 3 to reduce-scatter and allgather,
+        which is called "sequence parallelism". In this case, we also need
+        to specify the allgather point in kwargs, so we use:
+        ```python
+        sch["out_prj"].shard("weight", axis=1)
+        sch["out_prj"].sync(mode="fwd_post", sync_op_or_fn="reduce_scatter", axis=1)
+        sch["dropout"].sync(mode="fwd_post", sync_op_or_fn="all_gather", axis=1)
+        ```
+
+    Case 5: Custom sync function.
+        We may need additional logic when syncing the output. In this case,
+        we could use a custom sync function. Here is an example of sharding
+        a word embedding:
+        ```python
+        sch["wte"].shard("weight", axis=0)
+
+        def fwd_pre_hook(_module, _input):
+            ...
+        def fwd_post_hook(_module, _input, output):
+            ...
+        sch["wte"].sync(mode="fw_pre", sync_op_or_fn=fwd_pre_hook)
+        sch["wte"].sync(mode="fw_post", sync_op_or_fn=fwd_post_hook)
+        ```
+
+    Parameters
+    ----------
+    mode: str
+        Where to sync the output. Could be "fwd_pre", "fwd_post", or "bwd_post".
+    sync_op_or_fn: Union[str, Callable]
+        The sync_op_or_fn (e.g., all_gather, all_reduce, reduce_scatter) or
+        hook function.
+    kwargs: Dict[str, Any]
+        Additional arguments. For example, if sync_op_or_fn is specified,
+        axis is required for reduce_scatter and all_gather. Note that the axis
+        is the axis of the output tensor, not the input or weight tensor.
+    """
+
+    @staticmethod
+    def name():
+        return "sync"
+
+    @staticmethod
+    def apply(sch, mode, sync_op_or_fn, **kwargs):
+        # Generate the hook if sync_op_or_fn is a string.
+        if isinstance(sync_op_or_fn, str):
+            if mode == "fwd_post":
+                sync_fn = None
+                axis = kwargs.get("axis", 0)
+                if sync_op_or_fn == "all_gather":
+                    tensor_parallel_output_grad = kwargs.get(
+                        "tensor_parallel_output_grad", True
+                    )
+                    _validate_sync_op(sch, mode, sync_op_or_fn, axis)
+                    sync_fn = partial(
+                        all_gather_forward_output,
+                        dim=axis,
+                        group=sch.group,
+                        tensor_parallel_output_grad=tensor_parallel_output_grad,
+                    )
+                elif sync_op_or_fn == "reduce_scatter":
+                    _validate_sync_op(sch, mode, sync_op_or_fn)
+                    sync_fn = partial(
+                        reduce_scatter_forward_output, dim=axis, group=sch.group
+                    )
+                elif sync_op_or_fn == "scatter":
+                    _validate_sync_op(sch, mode, sync_op_or_fn)
+                    sync_fn = partial(scatter_forward_output, dim=axis, group=sch.group)
+                elif sync_op_or_fn == "all_reduce":
+                    _validate_sync_op(sch, mode, sync_op_or_fn)
+                    sync_fn = partial(reduce_forward_output, group=sch.group)
+                else:
+                    raise ValueError(
+                        f"Invalid sync_op_or_fn {sync_op_or_fn} for mode {mode} "
+                        "in {sch.path}."
+                    )
+
+                def hook_fn(_module, _input, output):
+                    output = sync_fn(output)
+                    return output
+
+            elif mode == "fwd_pre":
+                sync_fn = None
+                axis = kwargs.get("axis", 0)
+                if sync_op_or_fn == "all_gather":
+                    tensor_parallel_output_grad = kwargs.get(
+                        "tensor_parallel_output_grad", True
+                    )
+                    _validate_sync_op(sch, mode, sync_op_or_fn, axis)
+                    sync_fn = partial(
+                        all_gather_forward_output,
+                        dim=axis,
+                        group=sch.group,
+                        tensor_parallel_output_grad=tensor_parallel_output_grad,
+                    )
+                else:
+                    raise ValueError(
+                        f"Invalid sync_op_or_fn {sync_op_or_fn} for mode {mode} "
+                        "in {sch.path}."
+                    )
+
+                def hook_fn(_module, _input):
+                    _input = sync_fn(_input[0])
+                    return _input
+
+            elif mode == "bwd_post":
+                # We register this hook to forward pre hook, and
+                # use an autograd function to do the sync in backward.
+                # This is to avoid using backward hook which semantic is not clear.
+                if sync_op_or_fn == "all_reduce":
+                    _validate_sync_op(sch, mode, sync_op_or_fn)
+                    sync_fn = partial(reduce_backward_grad, group=sch.group)
+                    mode = "fwd_pre"
+                else:
+                    raise ValueError(
+                        f"Invalid sync_op_or_fn {sync_op_or_fn} for mode {mode} "
+                        "in {sch.path}."
+                    )
+
+                def hook_fn(_module, _input):
+                    _input = sync_fn(_input[0])
+                    return _input
+
+            else:
+                raise ValueError(
+                    f"Unsupported combination of mode {mode} and "
+                    f"sync_op_or_fn {sync_op_or_fn}. Please specify "
+                    "sync_op_or_fn as a hook function."
+                )
+        else:
+            hook_fn = sync_op_or_fn
+
+        if mode == "fwd_pre":
+            sch.mod.register_forward_pre_hook(hook_fn)
+        elif mode == "fwd_post":
+            sch.mod.register_forward_hook(hook_fn)
+        elif mode == "bwd_post":
+            sch.mod.register_full_backward_hook(hook_fn)
+        else:
+            raise ValueError(f"Unsupported mode {mode}.")

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -473,7 +473,7 @@ def list_primitives(name_only=True):
 
     Returns
     -------
-    Optional[list[str], dict[str, Primitive]]
+    Union[list[str], dict[str, Primitive]]
         If name_only, return a list of all available schedule primitives;
         otherwise return a dictionary mapping the name of the primitive to the
         primitive class.

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -462,33 +462,23 @@ class SubgraphWrapper(nn.Module):
         return False
 
 
-def list_primitives():
+def list_primitives(name_only=True):
     """List all available schedule primitives.
-
-    Returns
-    -------
-    list[str]
-        A list of all available schedule primitives.
-    """
-    return list(PRIMITIVES.keys())
-
-
-def desc_primitive(name):
-    """Describe a schedule primitive.
 
     Parameters
     ----------
-    name : str
-        The name of the primitive.
+    name_only : bool
+        If True, only return the name of the primitives. Otherwise, return the
+        primitive class.
 
     Returns
     -------
-    str
-        The description of the primitive.
+    Optional[list[str], dict[str, Primitive]]
+        If name_only, return a list of all available schedule primitives;
+        otherwise return a dictionary mapping the name of the primitive to the
+        primitive class.
     """
-    if name not in PRIMITIVES:
-        raise ValueError(f"Primitive {name} is not registered")
-    return PRIMITIVES[name].__doc__
+    return list(PRIMITIVES.keys()) if name_only else PRIMITIVES
 
 
 def create_schedule(

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -30,7 +30,7 @@ from .pipeline import (
 )
 from .sharding import (
     all_gather_forward_output,
-    get_output_type_after_sharding,
+    postproc_sharding,
     reduce_forward_output,
     reduce_backward_grad,
     reduce_scatter_forward_output,
@@ -302,7 +302,7 @@ class Schedule:
                         f"{gather_axis} is requested"
                     ) from None
 
-        out_type, out_part_axis = get_output_type_after_sharding(
+        out_type, out_part_axis = postproc_sharding(
             self.mod, tensor_name, sharded_size, axis
         )
         if out_type is not None:

--- a/slapo/sharding/__init__.py
+++ b/slapo/sharding/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Sharding utilities."""
 
-from .infer_type import *
+from .shard_ops import *
 from .sync_ops import (
     all_gather_forward_output,
     reduce_backward_grad,


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR refactors the schedule primitives to make them more systematic and extensible:
* Now all primitives derived the base class `Primitive` that defines the required APIs (`name`, `apply`, and optional `init_metadata`).
* The `apply` function takes the schedule as the first argument, followed by any primitive specific arguments.
* The `init_metadata` allows each primitive to register their metadata, so the original schedule metadata only defines tie_weights metadata now. Meanwhile, we currently also put some metadata, such as the original shape before sharding, directly to nn.Parameter. I'll send a follow-up PR to better organize them.
* All primitives are registered and maintained in a table, and they will be dynamically set to a schedule when it is constructed. In other words, users can register their primitives outside of the Slapo code base.

In addition this PR also
* Move build related functions to `build.py`.
* Rename `get_output_type_after_sharding` to `postproc_sharding`, because this function not only infers the output type but also changes the attributes (e.g., `in_feature`) after sharding.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @chhzh123 