### PR TITLE
[Primitive] .annotate() and .trace_until()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ We provide the following primitives for dynamic graph optimizations:
 | Synchronization | `s[op].sync(mode="fwd_pre/fwd_post/bwd_post", sync_op_or_fn, **kwargs)` |
 | Checkpointing | `s[op].checkpoint()` |
 | Fork random number generator | `s[op].fork_rng()` |
+| Annotate parameters | `s[op].annotate(param_name, key, value)` |
 
 And the following primitives for static graph optimizations:
 | Feature | Primitive |

--- a/slapo/model_schedule/albert.py
+++ b/slapo/model_schedule/albert.py
@@ -132,7 +132,7 @@ def generate_pipeline_schedule(sch, sch_config):
             if p.name not in input_names
         }
         _prefix = f"{prefix}." if prefix else ""
-        sch.trace_for_pipeline(
+        sch.trace_until(
             f"{_prefix}encoder", tracer="huggingface", concrete_args=concrete_args
         )
         for cut in pipeline_cuts:

--- a/slapo/model_schedule/bert.py
+++ b/slapo/model_schedule/bert.py
@@ -129,7 +129,7 @@ def generate_pipeline_schedule(sch, sch_config):
             if p.name not in input_names
         }
         _prefix = f"{prefix}." if prefix else ""
-        sch.trace_for_pipeline(
+        sch.trace_until(
             f"{_prefix}encoder", tracer="huggingface", concrete_args=concrete_args
         )
         for cut in pipeline_cuts:

--- a/slapo/model_schedule/opt.py
+++ b/slapo/model_schedule/opt.py
@@ -123,9 +123,7 @@ def generate_pipeline_schedule(sch, sch_config):
             for p in sig.parameters.values()
             if p.name not in input_names
         }
-        sch.trace_until(
-            f"{prefix}", tracer="huggingface", concrete_args=concrete_args
-        )
+        sch.trace_until(f"{prefix}", tracer="huggingface", concrete_args=concrete_args)
         _prefix = f"{prefix}." if prefix else ""
         for cut in pipeline_cuts:
             sch[f"{_prefix}h.{cut}"].cut_pipeline_stage()

--- a/slapo/model_schedule/opt.py
+++ b/slapo/model_schedule/opt.py
@@ -123,7 +123,7 @@ def generate_pipeline_schedule(sch, sch_config):
             for p in sig.parameters.values()
             if p.name not in input_names
         }
-        sch.trace_for_pipeline(
+        sch.trace_until(
             f"{prefix}", tracer="huggingface", concrete_args=concrete_args
         )
         _prefix = f"{prefix}." if prefix else ""

--- a/slapo/model_schedule/t5.py
+++ b/slapo/model_schedule/t5.py
@@ -186,7 +186,7 @@ def generate_pipeline_schedule(sch, sch_config):
             if p.name not in input_names
         }
         _prefix = f"{prefix}." if prefix else ""
-        sch.trace_for_pipeline(
+        sch.trace_until(
             [f"{_prefix}encoder", f"{_prefix}decoder"],
             tracer="huggingface",
             concrete_args=concrete_args,

--- a/slapo/model_schedule/wideresnet.py
+++ b/slapo/model_schedule/wideresnet.py
@@ -106,7 +106,7 @@ def generate_pipeline_schedule(sch, sch_config):
         _prefix = f"{prefix}." if prefix else ""
 
         leaves = [f"{_prefix}layer{idx + 1}" for idx in range(4) if pipeline_cuts[idx]]
-        sch.trace_for_pipeline(
+        sch.trace_until(
             leaves,
             tracer="pytorch",
             concrete_args=concrete_args,

--- a/slapo/primitives/annotate.py
+++ b/slapo/primitives/annotate.py
@@ -3,9 +3,8 @@
 """Annotation primitive."""
 # pylint: disable=arguments-differ
 
-from torch import nn
-
 from .base import register_primitive, Primitive
+
 
 @register_primitive()
 class AnnotateParamPrimitive(Primitive):

--- a/slapo/primitives/annotate.py
+++ b/slapo/primitives/annotate.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Annotation primitive."""
+# pylint: disable=arguments-differ
+
+from torch import nn
+
+from .base import register_primitive, Primitive
+
+@register_primitive()
+class AnnotateParamPrimitive(Primitive):
+    """Annotate an attribute to a parameter. The can be used to
+    maintain parameter specific metadata for sharding and consolidation, as
+    the schedule metadata is not preserved when the module is replaced.
+
+    Parameters
+    ----------
+    param_name : str
+        The name of the parameter to be annotated.
+    key : str
+        The key of the annotation.
+    value : Any
+        The value of the annotation.
+    """
+
+    @staticmethod
+    def name():
+        return "annotate"
+
+    @staticmethod
+    def apply(sch, param_name, key, value):
+        param = sch.mod.get_parameter(param_name)
+
+        # Add the key to the param_tags in the top schedule metadata,
+        # so that the annotations can be transferred to new parameter
+        # when it is replaced.
+        sch.get_top_schedule().metadata.param_tags.add(key)
+        setattr(param, key, value)

--- a/slapo/primitives/pipeline.py
+++ b/slapo/primitives/pipeline.py
@@ -39,7 +39,7 @@ class CutPipelineStagePrimitive(Primitive):
         if not isinstance(parent_sch.mod, fx.GraphModule):
             raise RuntimeError(
                 "Parent module has not been traced. "
-                "Please use 'trace_for_pipeline' to trace until "
+                "Please use 'trace_until' to trace until "
                 "the level you want to cut pipeline stages."
             )
 

--- a/slapo/primitives/tensor_parallel.py
+++ b/slapo/primitives/tensor_parallel.py
@@ -76,11 +76,10 @@ class ShardPrimitive(Primitive):
                     sch.metadata.tie_weights[param] = new_param
             else:
                 new_param = nn.Parameter(new_tensor)
-            # Tag param with model parallel attribute, used for grad clipping
-            new_param.tensor_model_parallel = True
-            # Save the original size of the parameter for consolidation.
-            new_param.orig_shape = param.shape
             sch.mod.register_parameter(tensor_name, new_param)
+
+            # Save the original size of the parameter for consolidation.
+            sch.annotate(tensor_name, "orig_shape", param.shape)
         except AttributeError:
             buffer = sch.mod.get_buffer(tensor_name)
             new_buffer, sharded_size = _shard(tensor_name, buffer)

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -39,6 +39,13 @@ fx.wrap(call_module)
 
 @dataclass
 class ScheduleMetadata:
+    """The metadata of a schedule. It is used to store the metadata of
+    primitives and the top module mainly for 1) verification and
+    2) applying framework dialects. Note that when replacing a module,
+    the schedule metadata of the original module is NOT transferred to the
+    new schedule, because the new module may not have the same structure
+    as the original module.
+    """
     # pylint: disable=unnecessary-lambda
 
     # Tie weight analysis only at the top level module.
@@ -48,6 +55,11 @@ class ScheduleMetadata:
     tie_weights: dict[nn.Parameter, nn.Parameter] = field(
         default_factory=lambda: OrderedDict()
     )
+
+    # The set of parameter tags added either by primitives or users.
+    # These tags will be transferred to the new parameter when it is replaced
+    # (e.g., sharding and consolidation).
+    param_tags: set[str] = field(default_factory=set)
 
     # Primitive specific metadata.
     primitives: dict[str, Any] = field(default_factory=lambda: OrderedDict())
@@ -148,6 +160,11 @@ class Schedule:
             if not curr_sch:
                 return False
         return True
+
+    def get_top_schedule(self):
+        if self.parent is None:
+            return self
+        return self.parent.get_top_schedule()
 
     def get_module(self, name):
         return dict(self.mod.named_modules())[name]
@@ -411,12 +428,22 @@ class SubgraphWrapper(nn.Module):
             return self.find_node(regex_or_pattern_fn)
         raise RuntimeError(f"Unrecognized pattern type {type(regex_or_pattern_fn)}")
 
-    def trace_for_pipeline(self, paths, **kwargs):
-        """Trace from the top module until the sub-module specified in path,
-        so that we can cut pipeline stages at the level."""
+    def trace_until(self, paths, **kwargs):
+        """A syntax sugar that traces from the top module until the sub-module
+        specified in path, so that we can apply computation optimization, such as
+        cutting pipeline stages at the level.
+
+        Parameters
+        ----------
+        paths : Union[str, List[str]]
+            The path to the sub-module that we want to trace until.
+        **kwargs
+            Other arguments for `trace` API.
+        """
+
         # Sanity check.
         if self.parent:
-            raise ValueError("trace_for_pipeline can only be called on the top module")
+            raise ValueError("trace_until can only be called on the top module")
         if isinstance(self.mod, fx.GraphModule):
             raise RuntimeError("Top module has been traced")
 
@@ -429,6 +456,7 @@ class SubgraphWrapper(nn.Module):
         concrete_args = kwargs.pop("concrete_args", {})
         self.trace(
             recursive=True,
+            flatten=False,
             leaf_modules=leaf_modules,
             tracer=tracer,
             concrete_args=concrete_args,

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -46,6 +46,7 @@ class ScheduleMetadata:
     new schedule, because the new module may not have the same structure
     as the original module.
     """
+
     # pylint: disable=unnecessary-lambda
 
     # Tie weight analysis only at the top level module.

--- a/slapo/utils/common.py
+++ b/slapo/utils/common.py
@@ -90,7 +90,8 @@ def transfer_hooks_for_fusion(sch, subgraphs, new_mod):
                 for hook in hook_types:
                     if has_hook(old_mod, hook) > 0:
                         raise RuntimeError(
-                            f"Cannot use horizontal fusion since module {node.target} has a {hook} hook"
+                            "Cannot use horizontal fusion since module "
+                            f"{node.target} has a {hook} hook"
                         )
     else:
         ops = subgraphs[0]
@@ -100,19 +101,28 @@ def transfer_hooks_for_fusion(sch, subgraphs, new_mod):
                 if i == 0:  # the first node
                     if has_hook(old_mod, "fwd_post"):
                         raise RuntimeError(
-                            f"Cannot transfer hooks from {node.target} to the new module since {node.target} has a fwd_post hook"
+                            f"Cannot transfer hooks from {node.target} to the "
+                            f"new module since {node.target} has a fwd_post hook"
                         )
                     transfer_hooks(old_mod, new_mod, ["fwd_pre", "bwd_post"])
                 elif i == len(ops) - 1:  # the last node
                     if has_hook(old_mod, "fwd_pre") or has_hook(old_mod, "bwd_post"):
                         raise RuntimeError(
-                            f"Cannot transfer hooks from {node.target} to the new module since {node.target} has a fwd_pre/bwd_post hook"
+                            f"Cannot transfer hooks from {node.target} to the new "
+                            f"module since {node.target} has a fwd_pre/bwd_post hook"
                         )
                     transfer_hooks(old_mod, new_mod, ["fwd_post"])
                 elif any(has_hook(old_mod, x) for x in hook_types):
                     raise RuntimeError(
-                        f"Cannot transfer hooks from {node.target} to the new module since {node.target} is in the middle of the subgraph"
+                        f"Cannot transfer hooks from {node.target} to the new module "
+                        f"since {node.target} is in the middle of the subgraph"
                     )
+
+
+def transfor_param_tags(sch, param, new_param):
+    for param_tag_name in sch.get_top_schedule().metadata.param_tags:
+        if hasattr(param, param_tag_name):
+            setattr(new_param, param_tag_name, getattr(param, param_tag_name))
 
 
 def is_lambda_function(obj):

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Test annotate primitive. Note that this test has to be invoked by torchrun.
+See ci/task_unit_tests.sh for an example.
+"""
+# pylint: disable=unused-argument
+
+import os
+
+import pytest
+import torch
+
+import slapo
+
+
+def test_shard_annotate(init_dist):
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer1 = torch.nn.Linear(32, 32, bias=False)
+            self.layer2 = torch.nn.Linear(32, 32, bias=False)
+
+        def forward(self, x):
+            x = self.layer1(x)
+            x = self.layer2(x)
+            return x
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    model = Model()
+
+    with slapo.init_empty_weights():
+        sch = slapo.create_schedule(model)
+
+    sch["layer1"].shard("weight", axis=0)
+    sch["layer1"].sync(mode="bwd_post", sync_op_or_fn="all_reduce")
+    sch["layer2"].shard("weight", axis=1)
+    sch["layer2"].sync(mode="fwd_post", sync_op_or_fn="all_reduce")
+    sch_model, _ = slapo.build(sch)
+
+    assert hasattr(sch_model.layer1.weight, "orig_shape")
+    assert hasattr(sch_model.layer2.weight, "orig_shape")
+
+
+def test_arbitrary_annotate():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer1 = torch.nn.Linear(32, 32, bias=False)
+            self.layer2 = torch.nn.Linear(32, 32, bias=False)
+
+        def forward(self, x):
+            x = self.layer1(x)
+            x = self.layer2(x)
+            return x
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    model = Model()
+
+    with slapo.init_empty_weights():
+        sch = slapo.create_schedule(model)
+
+    sch["layer1"].annotate("weight", "foo", "bar")
+    assert "foo" in sch.metadata.param_tags
+
+    sch_model, _ = slapo.build(sch)
+    assert sch_model.layer1.weight.foo == "bar"
+    assert not hasattr(sch_model.layer2.weight, "foo")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -4,7 +4,6 @@
 Test custom ops. Note that attn test has to be invoked by torchrun since
 most custom ops are for tensor parallelism.
 """
-# pylint: disable=unused-argument
 import pytest
 
 import torch


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

This PR introduces a new primitive `.annotate()` that sets an attribute to the assigned parameter. There are mainly two use cases:
1. When sharding, we record the original shape for model consolidation.
2. Runtime such as DeepSpeed pipeline may apply certain processes based on attributes (e.g., `tensor_model_parallel` or `replicated_param`).

The annotated attribute names will be maintained in the schedule metadata of the top module. The top module schedule will not be replaced, so the metadata is guaranteed to be propagated to the model building phase. To maintain the annotations, a utility `transfer_param_tags` is also introduced.

In addition, this PR also rename `.trace_for_pipeline()` to `.trace_until()`, because this API is not only for pipelining but could also be used for other optimizations.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @chhzh123 @szhengac 