### PR TITLE
[CI] Update CI rules for docs

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -11,6 +11,8 @@ on:
   # we cannot use AWS credential in this workflow. Instead, we trigger
   # another workflow to run the rest CI jobs on AWS batch.
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -7,9 +7,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 jobs:
   build:
@@ -19,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: docs
+        ref: ${{ github.ref }}
     # This step uses ammaraskar's Sphinx Build Action: https://github.com/ammaraskar/sphinx-action
     - uses: ammaraskar/sphinx-action@master
       with:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR updates the CI configuration file to make the documentation build only when the files in the `docs` folder are changed. Also, it changes the checkout branch to the current one instead of the `docs` branch (which is no longer maintained since it has been merged to the main branch).

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)

