### PR TITLE
[Primitive][fork_rng] Do not replace module

### DIFF
--- a/slapo/op/linear.py
+++ b/slapo/op/linear.py
@@ -99,6 +99,7 @@ class LinearWithSyncFunc(nn.Linear):
         sync_fn=None,
     ):
         super().__init__(in_features, out_features, bias, device, dtype)
+        self.traceable = False
         self.sync_fn = sync_fn
 
     def forward(self, x):

--- a/slapo/primitives/checkpoint.py
+++ b/slapo/primitives/checkpoint.py
@@ -34,6 +34,7 @@ class CheckpointPrimitive(Primitive):
         class CheckPointWrapper(nn.Module):
             def __init__(self, mod) -> None:
                 super().__init__()
+                self.traceable = False
                 self.mod = mod
 
             def forward(self, *args, **kwargs):

--- a/slapo/primitives/tensor_parallel.py
+++ b/slapo/primitives/tensor_parallel.py
@@ -3,12 +3,12 @@
 """Tensor parallel primitives."""
 # pylint: disable=arguments-differ
 
+import functools
 from collections import OrderedDict
 
-from torch import nn
-
 from ..random import get_cuda_rng_tracker
-from ..sharding import apply_shard_method, apply_sync_method, new_or_get_tied_param
+from ..sharding import (apply_shard_method, apply_sync_method,
+                        new_or_get_tied_param)
 from .base import Primitive, register_primitive
 
 
@@ -179,13 +179,13 @@ class ForkRNGPrimitive(Primitive):
 
     @staticmethod
     def apply(sch):
-        class ModuleWithForkedRNG(nn.Module):
-            def __init__(self, mod):
-                super().__init__()
-                self.mod = mod
-
-            def forward(self, *args, **kwargs):
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
                 with get_cuda_rng_tracker().fork():
-                    return self.mod(*args, **kwargs)
+                    return func(*args, **kwargs)
 
-        sch.replace(ModuleWithForkedRNG(sch.mod))
+            return wrapper
+            
+        sch.mod.forward = decorator(sch.mod.forward)
+

--- a/slapo/primitives/tensor_parallel.py
+++ b/slapo/primitives/tensor_parallel.py
@@ -7,8 +7,7 @@ import functools
 from collections import OrderedDict
 
 from ..random import get_cuda_rng_tracker
-from ..sharding import (apply_shard_method, apply_sync_method,
-                        new_or_get_tied_param)
+from ..sharding import apply_shard_method, apply_sync_method, new_or_get_tied_param
 from .base import Primitive, register_primitive
 
 
@@ -186,6 +185,6 @@ class ForkRNGPrimitive(Primitive):
                     return func(*args, **kwargs)
 
             return wrapper
-            
-        sch.mod.forward = decorator(sch.mod.forward)
 
+        sch.mod.forward = decorator(sch.mod.forward)
+        sch.mod.traceable = False

--- a/slapo/tracer.py
+++ b/slapo/tracer.py
@@ -22,14 +22,7 @@ logger = get_logger()
 
 
 def is_fx_tracable(mod):
-    return type(mod).__name__ not in [
-        "LinearWithSyncFunc",
-        "LinearWithAct",
-        "LinearWithDropout",
-    ]
-    # return not (
-    #     mod.__module__.startswith("slapo.op")
-    # )
+    return not hasattr(mod, "traceable") or mod.traceable
 
 
 def fix_hf_module(
@@ -50,7 +43,9 @@ def fix_hf_module(
         # Fix SelfAttention naming
         if node.op == "call_module" and "self" in node.target:
             logger.warning(
-                "`self` in {root.__class__.__name__} is a Python keyword, please rename it to avoid possible conflicts."
+                "`self` in %s is a Python keyword, "
+                "please rename it to avoid possible conflicts.",
+                root.__class__.__name__,
             )
     # Fix arguments
     for node in root_graph.nodes:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR changes the way of implementing `.fork_rng()`. Now it replaces the forward function instead of an entire module. However, this approach results in incorrect trace results. Specifically, this module can still be traced, but the traced graph is based on the original forward function, which is incorrect. As a result, this PR also introduces an internal attribute `.traceable` to `nn.Module`, and we check this attribute to determine whether a Slapo customized module is traceable.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @chhzh123 