### PR TITLE
[Bugfix] Shard embedding hooks

### DIFF
--- a/slapo/model_schedule/gpt2.py
+++ b/slapo/model_schedule/gpt2.py
@@ -348,9 +348,8 @@ def gen_embedding_hooks(sch, vocab_size):
         return masked_input
 
     def fwd_post_hook(_module, _input, output):
-        # Mask the output embedding
-        input_mask = (_input[0] < vocab_start_index) | (_input[0] >= vocab_end_index)
-        output[input_mask, :] = 0.0
+        # Mask the output embedding. Note that the input is already masked.
+        output[_input[0] == 0, :] = 0.0
         # Reduce across all the model parallel GPUs
         output = reduce_forward_output(output, sch.group)
         return output

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -478,8 +478,6 @@ def test_word_embedding(init_dist):
     data = torch.randint(1, vocab_size - 1, (1, 10)).cuda(local_rank)
     dist.broadcast(data, src=0)
     reset_random_seeds()
-    if rank == 0:
-        print(f"data {data}")
     out = sch_model(data)
     out.mean().backward()
 

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -19,6 +19,7 @@ from torch.nn import functional as F
 
 import slapo
 from slapo import op
+from slapo.model_schedule.gpt2 import gen_embedding_hooks
 
 from .utils import reset_random_seeds
 
@@ -446,6 +447,56 @@ def test_conv(init_dist):
 
         torch.testing.assert_close(out, out_ref)
         torch.testing.assert_allclose(data_grad, data.grad)
+        verify_grads(model, path_and_grads)
+
+
+def test_word_embedding(init_dist):
+    """Test whether sharding embedding using custom hooks is numerically correct."""
+    vocab_size = 100
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = nn.Embedding(vocab_size, 10)  # vocab_size, hidden_size
+
+        def forward(self, x):
+            return self.embedding(x)
+
+    rank = dist.get_rank()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    model = Model()
+
+    sch = slapo.create_schedule(copy.deepcopy(model))
+    sch["embedding"].shard("weight", axis=0)
+    fwd_pre_hook, fwd_post_hook = gen_embedding_hooks(sch, vocab_size)
+    sch["embedding"].sync(mode="fwd_pre", sync_op_or_fn=fwd_pre_hook)
+    sch["embedding"].sync(mode="fwd_post", sync_op_or_fn=fwd_post_hook)
+    sch_model, _ = slapo.build(sch, init_weights=False)
+
+    sch_model.cuda(local_rank)
+    data = torch.randint(1, vocab_size - 1, (1, 10)).cuda(local_rank)
+    dist.broadcast(data, src=0)
+    reset_random_seeds()
+    if rank == 0:
+        print(f"data {data}")
+    out = sch_model(data)
+    out.mean().backward()
+
+    param_path_and_gather_axis = {
+        "embedding.weight": 0,
+    }
+    path_and_grads = gather_grad(sch_model, param_path_and_gather_axis)
+
+    gather_and_copy_model(sch_model, model, param_path_and_gather_axis)
+
+    reset_random_seeds()
+    if rank == 0:
+        model.cuda(local_rank)
+        out_ref = model(data)
+        out_ref.mean().backward()
+
+        torch.testing.assert_close(out, out_ref)
         verify_grads(model, path_and_grads)
 
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
When sharding word embedding, we use forward pre-hook to mask inputs for different devices in a TP group. Accordingly, we have to mask the invalid output using the same mask in forward post-hook. Since the input mask generated in pre-hook cannot be saved, we currently re-generate the mask in post-hook. However, at this moment the input is already masked, so we cannot re-generate a mask using the same logic.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @chhzh123 @zarzen 