### PR TITLE
[Version] Refactor version updating logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,12 +62,17 @@ def get_version():
         "--match",
         "v[0-9]*.[0-9]*.dev[0-9]*",
     ]
-    proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=ROOT_DIR
-    )
-    (out, _) = proc.communicate()
+    try:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=ROOT_DIR
+        )
+        (out, _) = proc.communicate()
+        retcode = proc.returncode
+    except Exception as err:
+        out = str(err)
+        retcode = -1
 
-    if proc.returncode != 0:
+    if retcode != 0:
         msg = py_str(out)
         if msg.find("not a git repository") != -1:
             return curr_version, curr_version

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,111 @@
 
 import os
 import re
+import subprocess
+
 import setuptools
 
 ROOT_DIR = os.path.dirname(__file__)
 
 
-def get_version():
-    with open(os.path.join(ROOT_DIR, "slapo", "version.py")) as fp:
+def get_version_in_version_py(root_dir):
+    """Get the current version specified in version.py."""
+    with open(os.path.join(root_dir, "slapo", "version.py")) as fp:
         version_match = re.search(
             r"^__version__ = ['\"]([^'\"]*)['\"]", fp.read(), re.M
         )
         if version_match:
             return version_match.group(1)
     raise RuntimeError("Unable to find version string")
+
+
+def py_str(cstr):
+    return cstr.decode("utf-8")
+
+
+def get_version():
+    """Get PEP-440 compatible public and local version using git describe.
+    If not applicable, fallback to the version specified in version.py.
+
+    Returns
+    -------
+    pub_ver: str
+        Public version.
+    local_ver: str
+        Local version (with additional label appended to pub_ver).
+
+    Notes
+    -----
+    - We follow PEP 440's convention of public version
+      and local versions.
+    - Only tags conforming to vMAJOR.MINOR.REV (e.g. "v0.7.0")
+      are considered in order to generate the version string.
+      See the use of `--match` in the `git` command below.
+    Here are some examples:
+    - pub_ver = '0.7.0', local_ver = '0.7.0':
+      We are at the 0.7.0 release.
+    - pub_ver =  '0.8.dev94', local_ver = '0.8.dev94+g0d07a329e':
+      We are at the the 0.8 development cycle.
+      The current source contains 94 additional commits
+      after the most recent tag(v0.7.0),
+      the git short hash tag of the current commit is 0d07a329e.
+    """
+    curr_version = get_version_in_version_py(ROOT_DIR)
+    cmd = [
+        "git",
+        "describe",
+        "--tags",
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+        "--match",
+        "v[0-9]*.[0-9]*.dev[0-9]*",
+    ]
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=ROOT_DIR
+    )
+    (out, _) = proc.communicate()
+
+    if proc.returncode != 0:
+        msg = py_str(out)
+        if msg.find("not a git repository") != -1:
+            return curr_version, curr_version
+        print("WARNING: git describe: %s, use %s", msg, curr_version)
+        return curr_version, curr_version
+    describe = py_str(out).strip()
+    arr_info = describe.split("-")
+
+    # Remove the v prefix, mainly to be robust
+    # to the case where v is not presented as well.
+    if arr_info[0].startswith("v"):
+        arr_info[0] = arr_info[0][1:]
+
+    # Hit the exact tag (stable version).
+    if len(arr_info) == 1:
+        return arr_info[0], arr_info[0]
+
+    if len(arr_info) != 3:
+        print("WARNING: Invalid output from git describe %s", describe)
+        return curr_version, curr_version
+
+    dev_pos = arr_info[0].find(".dev")
+
+    # Development versions:
+    # The code will reach this point in case it can't match a full release version,
+    # such as v0.7.0.
+    #
+    # 1. in case the last known label looks like vMAJ.MIN.devN e.g. v0.8.dev0, we use
+    # the current behaviour of just using vMAJ.MIN.devNNNN+gGIT_REV
+    if dev_pos != -1:
+        dev_version = arr_info[0][: arr_info[0].find(".dev")]
+    # 2. in case the last known label looks like vMAJ.MIN.PATCH e.g. v0.8.0
+    # then we just carry on with a similar version to what git describe provides,
+    # which is vMAJ.MIN.PATCH.devNNNN+gGIT_REV
+    else:
+        dev_version = arr_info[0]
+
+    pub_ver = "%s.dev%s" % (dev_version, arr_info[1])
+    local_ver = "%s+%s" % (pub_ver, arr_info[2])
+    return pub_ver, local_ver
 
 
 def setup():
@@ -25,7 +117,7 @@ def setup():
     setuptools.setup(
         name="slapo",
         description="Slapo: A Schedule Language for Progressive Optimization.",
-        version=get_version(),
+        version=get_version()[1],
         author="Slapo Community",
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -67,18 +67,18 @@ def get_version():
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=ROOT_DIR
         )
         (out, _) = proc.communicate()
+        msg = py_str(out)
         retcode = proc.returncode
     except Exception as err:
-        out = str(err)
+        msg = str(err)
         retcode = -1
 
     if retcode != 0:
-        msg = py_str(out)
         if msg.find("not a git repository") != -1:
             return curr_version, curr_version
         print("WARNING: git describe: %s, use %s", msg, curr_version)
         return curr_version, curr_version
-    describe = py_str(out).strip()
+    describe = msg.strip()
     arr_info = describe.split("-")
 
     # Remove the v prefix, mainly to be robust

--- a/slapo/version.py
+++ b/slapo/version.py
@@ -6,4 +6,4 @@ This file should not be changed manually. The steps of bumping a version are:
 2. Run git fetch --tags to fetch the new tag.
 3. Run python update_version.py to update the version information in this file.
 """
-__version__ = "0.0.1.dev0"
+__version__ = "0.0.2.dev0"

--- a/update_version.py
+++ b/update_version.py
@@ -12,143 +12,58 @@ import os
 import re
 import argparse
 import logging
-import subprocess
 
-# Modify the following value during release
-# -----------------------------------------
-# Current version:
-# We use the version of the incoming release for code
-# that is under development.
-#
-# It is also fallback version to be used when --git-describe
-# is not invoked, or when the repository does not present the
-# git tags in a format that this script can use.
-#
-# Two tag formats are supported:
-# - vMAJ.MIN.PATCH (e.g. v0.8.0) or
-# - vMAJ.MIN.devN (e.g. v0.8.dev0)
-__version__ = "v0.1.dev0"
+from setup import get_version, get_version_in_version_py
 
-# ---------------------------------------------------
 
 PROJ_ROOT = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-
-
-def py_str(cstr):
-    return cstr.decode("utf-8")
-
-
-def git_describe_version():
-    """Get PEP-440 compatible public and local version using git describe.
-    Returns
-    -------
-    pub_ver: str
-        Public version.
-    local_ver: str
-        Local version (with additional label appended to pub_ver).
-    Notes
-    -----
-    - We follow PEP 440's convention of public version
-      and local versions.
-    - Only tags conforming to vMAJOR.MINOR.REV (e.g. "v0.7.0")
-      are considered in order to generate the version string.
-      See the use of `--match` in the `git` command below.
-    Here are some examples:
-    - pub_ver = '0.7.0', local_ver = '0.7.0':
-      We are at the 0.7.0 release.
-    - pub_ver =  '0.8.dev94', local_ver = '0.8.dev94+g0d07a329e':
-      We are at the the 0.8 development cycle.
-      The current source contains 94 additional commits
-      after the most recent tag(v0.7.0),
-      the git short hash tag of the current commit is 0d07a329e.
-    """
-    cmd = [
-        "git",
-        "describe",
-        "--tags",
-        "--match",
-        "v[0-9]*.[0-9]*.[0-9]*",
-        "--match",
-        "v[0-9]*.[0-9]*.dev[0-9]*",
-    ]
-    proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=PROJ_ROOT
-    )
-    (out, _) = proc.communicate()
-
-    if proc.returncode != 0:
-        msg = py_str(out)
-        if msg.find("not a git repository") != -1:
-            return __version__, __version__
-        logging.warning("git describe: %s, use %s", msg, __version__)
-        return __version__, __version__
-    describe = py_str(out).strip()
-    arr_info = describe.split("-")
-
-    # Remove the v prefix, mainly to be robust
-    # to the case where v is not presented as well.
-    if arr_info[0].startswith("v"):
-        arr_info[0] = arr_info[0][1:]
-
-    # hit the exact tag
-    if len(arr_info) == 1:
-        return arr_info[0], arr_info[0]
-
-    if len(arr_info) != 3:
-        logging.warning("Invalid output from git describe %s", describe)
-        return __version__, __version__
-
-    dev_pos = arr_info[0].find(".dev")
-
-    # Development versions:
-    # The code will reach this point in case it can't match a full release version,
-    # such as v0.7.0.
-    #
-    # 1. in case the last known label looks like vMAJ.MIN.devN e.g. v0.8.dev0, we use
-    # the current behaviour of just using vMAJ.MIN.devNNNN+gGIT_REV
-    if dev_pos != -1:
-        dev_version = arr_info[0][: arr_info[0].find(".dev")]
-    # 2. in case the last known label looks like vMAJ.MIN.PATCH e.g. v0.8.0
-    # then we just carry on with a similar version to what git describe provides,
-    # which is vMAJ.MIN.PATCH.devNNNN+gGIT_REV
-    else:
-        dev_version = arr_info[0]
-
-    pub_ver = "%s.dev%s" % (dev_version, arr_info[1])
-    local_ver = "%s+%s" % (pub_ver, arr_info[2])
-    return pub_ver, local_ver
+CURR_VERSON = get_version_in_version_py(PROJ_ROOT)
 
 
 # Implementations
 def update(file_name, pattern, repl, dry_run=False):
+    """Update the version specified in the given file using the given pattern."""
     update = []
     hit_counter = 0
     need_update = False
     with open(file_name) as file:
-        for l in file:
-            result = re.findall(pattern, l)
+        for line in file:
+            result = re.findall(pattern, line)
             if result:
                 assert len(result) == 1
                 hit_counter += 1
                 if result[0] != repl:
-                    l = re.sub(pattern, repl, l)
+                    line = re.sub(pattern, repl, line)
                     need_update = True
                     print("%s: %s -> %s" % (file_name, result[0], repl))
                 else:
                     print("%s: version is already %s" % (file_name, repl))
 
-            update.append(l)
+            update.append(line)
     if hit_counter != 1:
         raise RuntimeError("Cannot find version in %s" % file_name)
 
     if need_update and not dry_run:
         with open(file_name, "w") as output_file:
-            for l in update:
-                output_file.write(l)
+            for line in update:
+                output_file.write(line)
 
 
 def sync_version(pub_ver, local_ver, dry_run):
     """Synchronize version."""
+
+    # Sanity check.
+    target_ver = pub_ver
+    if pub_ver.find("dev") != -1:
+        target_ver = pub_ver[: pub_ver.find(".dev")]
+
+    if not CURR_VERSON.startswith(target_ver):
+        raise RuntimeError(
+            f"The existing version ({CURR_VERSON}) is not the dev version of "
+            f"the target version ({target_ver}). Please update the version.py "
+            f"manually to {target_ver}.dev0, commit and re-tag."
+        )
+
     # python uses the PEP-440: local version
     update(
         os.path.join(PROJ_ROOT, "slapo", "version.py"),
@@ -174,9 +89,10 @@ def main():
     parser.add_argument("--dry-run", action="store_true")
 
     opt = parser.parse_args()
-    pub_ver, local_ver = __version__, __version__
+    pub_ver, local_ver = CURR_VERSON, CURR_VERSON
     if opt.git_describe:
-        pub_ver, local_ver = git_describe_version()
+        pub_ver, local_ver = get_version()
+
     if opt.print_version:
         print(local_ver)
     else:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

I realized that I forgot to bump the version in `slapo/version.py` to `v0.0.2.dev0` in the last release. This results in some confusions, because when user install Slapo from source, they still see `v0.0.1.dev0`. This PR refactors the version updating logic to prevent this case from happening again in the future release.

1. Make `slapo/version.py` the only place to specify the current dev version.
2. Add a sanity check when building a wheel. Specifically, if it attempts to update the version from `v0.0.x.dev0` in version.py to `v0.0.y` where `y != x` , then errors out. This is used to make sure we bump the version in `version.py` before releasing a new stable version.
3. Align the version when installing with `setup.py`.

In short, with this PR we now have the following behaviors:
1. When installing from source (e.g., `pip3 install -e ".[dev]"`), the version shown by `pip3 show slapo` would be the formal version (e.g., `0.0.2.dev13+g44aea26`). Note that since we didn't change `slapo/version.py`, we will still see `0.0.2.dev0` if `python3 -c "import slapo; print(slapo.__version__)"`. This is intentional.
2. Before building a wheel for release, `build_wheel.sh` invokes `update_version.py`, which modifies `slapo/version.py` to be the current version. Thus, the version specified in the wheel reflects the current commit. With the sanity check added in this PR, assuming we are going to release `v0.0.3`, before adding a tag to the repo, we require the version specified in `slapo/version.py` to be `0.0.3.dev0`; otherwise `update_version.py` will error out.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @chhzh123 