### PR TITLE
[Primitive] Add .replace_all()

### DIFF
--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -280,3 +280,30 @@ class ReplacePrimitive(Primitive):
                         sch,
                         sch.group,
                     )
+
+
+@register_primitive()
+class ReplaceAllPrimitive(Primitive):
+    """Replace all the specified submodules with the new module.
+
+    Parameters
+    ----------
+    sch : Schedule
+        The schedule with the module/function to be replaced.
+    target_mod_type : Type
+        A target nn.Module type to be replaced.
+    new_mod : nn.Module
+        The new module to replace the target module.
+    """
+
+    @staticmethod
+    def name():
+        return "replace_all"
+
+    @staticmethod
+    def apply(sch, target_mod_type, new_mod):
+        module_names = dict(sch.mod.named_modules()).keys()
+        for name in module_names:
+            subsch = sch[name]
+            if isinstance(subsch.mod, target_mod_type):
+                subsch.replace(new_mod)

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -292,8 +292,8 @@ class ReplaceAllPrimitive(Primitive):
         The schedule with the module/function to be replaced.
     target_mod_type : Type
         A target nn.Module type to be replaced.
-    new_mod : nn.Module
-        The new module to replace the target module.
+    make_mod_fn : FunctionType
+        A function that takes the original module and generate a new module.
     """
 
     @staticmethod
@@ -301,9 +301,10 @@ class ReplaceAllPrimitive(Primitive):
         return "replace_all"
 
     @staticmethod
-    def apply(sch, target_mod_type, new_mod):
+    def apply(sch, target_mod_type, make_mod_fn):
         module_names = dict(sch.mod.named_modules()).keys()
         for name in module_names:
             subsch = sch[name]
             if isinstance(subsch.mod, target_mod_type):
+                new_mod = make_mod_fn(name, subsch.mod)
                 subsch.replace(new_mod)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -33,6 +33,44 @@ def test_replace_single_module():
     assert isinstance(sch["activation"].mod, nn.GELU)
 
 
+def test_replace_all_module():
+    class SubMod(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(1024, 1024)
+            self.activation = nn.ReLU()
+
+        def forward(self, x):
+            x = self.linear(x)
+            x = self.activation(x)
+            return x
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(1024, 1024)
+            self.act1 = nn.ReLU()
+            self.fc2 = nn.Linear(1024, 1024)
+            self.act2 = nn.ReLU()
+            self.submod = SubMod()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.act1(x)
+            x = self.fc2(x)
+            x = self.act2(x)
+            x = self.submod(x)
+            return x
+
+    model = Model()
+    sch = slapo.create_schedule(model)
+    new_act = nn.GELU()
+    sch.replace_all(nn.ReLU, new_act)
+    assert isinstance(sch["act1"].mod, nn.GELU)
+    assert isinstance(sch["act2"].mod, nn.GELU)
+    assert isinstance(sch["submod.activation"].mod, nn.GELU)
+
+
 def test_vertical_replacement():
     class Model(nn.Module):
         def __init__(self):


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR add a new `.replace_all()` primitive for users to quickly replace all the submodules that satisfy certain type constraints with the new module.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac 