### PR TITLE
[API] Add .named_schedules()

### DIFF
--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -293,7 +293,7 @@ class ReplaceAllPrimitive(Primitive):
     target_mod_type : Type
         A target nn.Module type to be replaced.
     make_mod_fn : FunctionType
-        A function that takes the original module and generate a new module.
+        A function that takes the path of the original module and the module itself and generate a new module.
     """
 
     @staticmethod
@@ -302,9 +302,7 @@ class ReplaceAllPrimitive(Primitive):
 
     @staticmethod
     def apply(sch, target_mod_type, make_mod_fn):
-        module_names = dict(sch.mod.named_modules()).keys()
-        for name in module_names:
-            subsch = sch[name]
+        for name, subsch in sch.named_schedules():
             if isinstance(subsch.mod, target_mod_type):
                 new_mod = make_mod_fn(name, subsch.mod)
                 subsch.replace(new_mod)

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -170,6 +170,16 @@ class Schedule:
     def get_module(self, name):
         return dict(self.mod.named_modules())[name]
 
+    def named_schedules(self, prefix: str = ""):
+        r"""Returns an iterator over all subschedules in the current schedule, yielding
+        both the name of the subschedule as well as the subschedule itself.
+        """
+        yield prefix, self
+        for name, subsch in self.child.items():
+            subsch_prefix = prefix + ("." if prefix else "") + name
+            for m in subsch.named_schedules(subsch_prefix):
+                yield m
+
     def _construct_fx_graph(self, subgraph):
         """Construct a new fx.Graph based on the subgraph extracted from the
         original graph. This function should NOT be called directly.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_submodule():
     mod = Model()
     sch = slapo.create_schedule(mod)
     subschs = dict(sch.named_schedules())
-    for name in [
+    for name in {
         "fc1",
         "act1",
         "fc2",
@@ -48,7 +48,7 @@ def test_submodule():
         "submod",
         "submod.linear",
         "submod.activation",
-    ]:
+    }:
         assert name in subschs
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test utilities."""
+
+import pytest
+from torch import nn
+
+import slapo
+
+
+def test_submodule():
+    class SubMod(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(1024, 1024)
+            self.activation = nn.ReLU()
+
+        def forward(self, x):
+            x = self.linear(x)
+            x = self.activation(x)
+            return x
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(1024, 1024)
+            self.act1 = nn.ReLU()
+            self.fc2 = nn.Linear(1024, 1024)
+            self.act2 = nn.ReLU()
+            self.submod = SubMod()
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = self.act1(x)
+            x = self.fc2(x)
+            x = self.act2(x)
+            x = self.submod(x)
+            return x
+
+    mod = Model()
+    sch = slapo.create_schedule(mod)
+    subschs = dict(sch.named_schedules())
+    for name in [
+        "fc1",
+        "act1",
+        "fc2",
+        "act2",
+        "submod",
+        "submod.linear",
+        "submod.activation",
+    ]:
+        assert name in subschs
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_submodule():
     mod = Model()
     sch = slapo.create_schedule(mod)
     subschs = dict(sch.named_schedules())
-    for name in {
+    for name in (
         "fc1",
         "act1",
         "fc2",
@@ -48,7 +48,7 @@ def test_submodule():
         "submod",
         "submod.linear",
         "submod.activation",
-    }:
+    ):
         assert name in subschs
 
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR introduces a new API `.named_schedules` to traverse all the subschedules, similar to `.named_modules()` in PyTorch. This can avoid the mismatching between `nn.ModuleList` and the created schedule.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac 
