### PR TITLE
[Primitive] Add kwargs to .replace_all()

### DIFF
--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -294,6 +294,8 @@ class ReplaceAllPrimitive(Primitive):
         A target nn.Module type to be replaced.
     make_mod_fn : FunctionType
         A function that takes the path of the original module and the module itself and generate a new module.
+    kwargs : Dict[str, Any]
+        The keyword arguments for make_mod_fn.
     """
 
     @staticmethod
@@ -301,8 +303,8 @@ class ReplaceAllPrimitive(Primitive):
         return "replace_all"
 
     @staticmethod
-    def apply(sch, target_mod_type, make_mod_fn):
-        for name, subsch in sch.named_schedules():
+    def apply(sch, target_mod_type, make_mod_fn, **kwargs):
+        for name, subsch in dict(sch.named_schedules()).items():
             if isinstance(subsch.mod, target_mod_type):
-                new_mod = make_mod_fn(name, subsch.mod)
+                new_mod = make_mod_fn(name, subsch.mod, **kwargs)
                 subsch.replace(new_mod)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -381,5 +381,4 @@ def test_transfer_hook():
 
 
 if __name__ == "__main__":
-    test_replace_all_with_seq()
-    # pytest.main([__file__])
+    pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes two issues:
1. Previous implementation leverages `.named_schedule()` to get all the subschedules, which is a generator that generates the subschedules on-the-fly. However, when the user replaced module accidentally includes the original module, it will get into a infinite loop. One practical example is to replace `nn.Linear` with an inherited module or a sequential module that contains a `nn.Linear` layer. To fix it, we need to get all the subschedules first, and then replace them one by one.
2. Add `**kwargs` to `.replace_all()`, enabling users to pass additional arguments to the module constructor.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac 