### PR TITLE
[Fix] Silent tracing error

### DIFF
--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -494,7 +494,7 @@ class SubgraphWrapper(nn.Module):
             "either due to the incorrect tracer/concrete args, or the limtation "
             "in torch.fx.",
             self.path,
-            failed_msg,
+            "Check the above error messages" if failed_msg is None else failed_msg,
             self.path,
             self.path,
         )

--- a/slapo/tracer.py
+++ b/slapo/tracer.py
@@ -182,16 +182,16 @@ def trace_submodule(
                 root, concrete_args=concrete_args, dummy_inputs=dummy_inputs
             )
         except Exception as err:
-            logger.debug(traceback.format_exc())
-            logger.debug("Cannot trace module %s: %s", root.__class__.__name__, err)
+            logger.warning(traceback.format_exc())
+            logger.warning("Cannot trace module %s: %s", root.__class__.__name__, err)
             return root
     else:
         concrete_args = kwargs.get("concrete_args", {})
         try:
             root_graph = tracer.trace(root, concrete_args=concrete_args)
         except Exception as err:
-            logger.debug(traceback.format_exc())
-            logger.debug("Cannot trace module %s: %s", root.__class__.__name__, err)
+            logger.warning(traceback.format_exc())
+            logger.warning("Cannot trace module %s: %s", root.__class__.__name__, err)
             return root
     call_arg_map = {}
     for node in root_graph.nodes:


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR is a quick fix for silent tracing errors. Currently users cannot see the traceback error messages when the tracer fails, which makes debugging extremely intractable.