### PR TITLE
[Bugfix] Fix QKV matching

### DIFF
--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -345,10 +345,10 @@ class Schedule:
             #  z = x + 1
             # The implication here is that the generated pattern graph should follows **the same
             # topological order** of the original graph. Otherwise, the current implementation
-            # will not be able to match the pattern graph. In general, subgraph isophorphism
-            # is a NP-complete problem, and the current implementation is a greedy algorithm
-            # that leverages the sequential representation of the computaional graph.
-            # 
+            # will not be able to match the pattern graph. In general, subgraph isomorphism
+            # is an NP-complete problem, and the current implementation is a greedy algorithm
+            # that leverages the property of sequential representation of the computation graph.
+            #
             # The successor of the last operation of the fx graph is binded to the root node,
             # so when ptr.op == "root", it means it reaches the end of the graph.
             while ptr.op != "root":

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -329,6 +329,25 @@ class Schedule:
                 subgraphs.append((parent_name, curr))
             ptr = curr.next
             found = False
+            # This loop is supposed to tackle the following case that the
+            # user of the current node is not the immediate successor, which requires
+            # iteratively traverse the graph until it finds the user or reaches the
+            # end of the graph. An example is shown below:
+            # original graph:
+            #  x = a + b
+            #  y = c + d (totally independent from x)
+            #  z = x + 1
+            # pattern graph:
+            #  m = p + q
+            #  n = m + 1
+            # should match:
+            #  x = a + b
+            #  z = x + 1
+            # The implication here is that the generated pattern graph should follows the same
+            # topological order of the original graph. Otherwise, the current implementation
+            # will not be able to match the pattern graph. In general, subgraph isophorphism
+            # is a NP-complete problem, and the current implementation is a greedy algorithm
+            # that leverages the sequential representation of the computaional graph.
             while ptr.op != "root":
                 if find_match_subgraphs(ptr, target.next, subgraphs):
                     found = True

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -327,12 +327,14 @@ class Schedule:
             if (parent_name, curr) not in subgraphs:
                 # New matched.
                 subgraphs.append((parent_name, curr))
-            matched = True
-            if curr.next != curr and target.next != target:
-                matched = matched and find_match_subgraphs(
-                    curr.next, target.next, subgraphs
-                )
-            return matched
+            ptr = curr.next
+            found = False
+            while ptr.op != "root":
+                if find_match_subgraphs(ptr, target.next, subgraphs):
+                    found = True
+                    break
+                ptr = ptr.next
+            return found
 
         self.trace()
 
@@ -349,7 +351,8 @@ class Schedule:
                 closure_vars = inspect.getclosurevars(pattern_fn)
                 closure_code = ""
                 for key, value in closure_vars.nonlocals.items():
-                    closure_code += f"{key} = {value}\n"
+                    if not callable(value):
+                        closure_code += f"{key} = {value}\n"
                 formatted_code = ""
                 indent = ""
                 for line in src_code:

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -343,11 +343,14 @@ class Schedule:
             # should match:
             #  x = a + b
             #  z = x + 1
-            # The implication here is that the generated pattern graph should follows the same
-            # topological order of the original graph. Otherwise, the current implementation
+            # The implication here is that the generated pattern graph should follows **the same
+            # topological order** of the original graph. Otherwise, the current implementation
             # will not be able to match the pattern graph. In general, subgraph isophorphism
             # is a NP-complete problem, and the current implementation is a greedy algorithm
             # that leverages the sequential representation of the computaional graph.
+            # 
+            # The successor of the last operation of the fx graph is binded to the root node,
+            # so when ptr.op == "root", it means it reaches the end of the graph.
             while ptr.op != "root":
                 if find_match_subgraphs(ptr, target.next, subgraphs):
                     found = True

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -281,5 +281,42 @@ def test_pattern_call_module_class():
         assert isinstance(sch.get_module(subgraph[i][1][1].target), nn.ReLU)
 
 
+def test_qkv():
+    from transformers import BertLMHeadModel, AutoConfig
+    import inspect
+    import torch.fx as fx
+
+    config = AutoConfig.from_pretrained("bert-large-uncased")
+    model = BertLMHeadModel(config)
+
+    sch = slapo.create_schedule(model)
+    input_names = ["hidden_states"]
+    subsch = sch["bert.encoder.layer.0.attention"]
+    sig = inspect.signature(subsch.mod.forward)
+    concrete_args = {
+        p.name: p.default for p in sig.parameters.values() if p.name not in input_names
+    }
+    subsch.trace(
+        recursive=False, flatten=True, tracer="pytorch", concrete_args=concrete_args
+    )
+    assert isinstance(subsch.mod, fx.GraphModule)
+
+    from slapo.pattern import call_module
+
+    def pattern(x):
+        x = call_module(r"self\.(query|key|value)", x)
+        new_shape = x.size()[:-1] + (16, -1)
+        x = x.view(new_shape)
+        return x.permute(0, 2, 1, 3)
+
+    qkv_subgraphs = subsch.find(pattern)
+    assert len(qkv_subgraphs) == 3
+    for subgraph in qkv_subgraphs:
+        assert len(subgraph) == 6
+    assert qkv_subgraphs[0][0][1].target == "self.query"
+    assert qkv_subgraphs[1][0][1].target == "self.key"
+    assert qkv_subgraphs[2][0][1].target == "self.value"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -284,7 +284,7 @@ def test_pattern_call_module_class():
 def test_qkv():
     from transformers import BertLMHeadModel, AutoConfig
     import inspect
-    import torch.fx as fx
+    from torch import fx
 
     config = AutoConfig.from_pretrained("bert-large-uncased")
     model = BertLMHeadModel(config)
@@ -300,8 +300,6 @@ def test_qkv():
         recursive=False, flatten=True, tracer="pytorch", concrete_args=concrete_args
     )
     assert isinstance(subsch.mod, fx.GraphModule)
-
-    from slapo.pattern import call_module
 
     def pattern(x):
         x = call_module(r"self\.(query|key|value)", x)
@@ -339,7 +337,8 @@ def test_diamond():
             b1 = a * 5  # useless op
             c = a * 3
             d = b + c
-            return d
+            e = b1 + d  # useless op
+            return e
 
     sch = slapo.create_schedule(Diamond())
 


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR is an enhancement to #58. Although #58 adds support for tree-like subgraph matching, it makes the original QKV matching invalid. This is because the user of a graph node may not be the immediate successor of it, so we need to iteratively find its correct user. For the following case, `y` is not the user of `x` but is the immediate successor of `x`. When we do the pattern matching, we need to skip `y` but to match `z`.

```python
# original graph
x = a + b
y = c + d (totally independent from x)
z = x + 1
# pattern graph:
m = p + q
n = m + 1
```

In general, subgraph isomorphism is an NP-complete problem, and the current implementation is a greedy algorithm that leverages the property of sequential representation of the computation graph, but it cannot guarantee all the patterns can be matched.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac 