### PR TITLE
[Verification] Enhanced verifier for end-to-end HF model testing

### DIFF
--- a/slapo/build.py
+++ b/slapo/build.py
@@ -177,7 +177,10 @@ def consolidate_model(
                 # those parameters can be handled within that function.
                 for param_name, param in sch.mod.named_parameters(recurse=False):
                     logger.info(
-                        f"Param {param_name} in Module {sch.path}.{sch.name} is initialized as all zeros"
+                        "Param %s in Module %s.%s is initialized as all zeros",
+                        param_name,
+                        sch.path,
+                        sch.name,
                     )
 
         # Broadcast complete params from rank 0 to make sure all the TP+DP ranks

--- a/slapo/build.py
+++ b/slapo/build.py
@@ -173,7 +173,7 @@ def consolidate_model(
                 # https://github.com/huggingface/transformers/blob/main/src/transformers/models/bert/modeling_bert.py#L693
                 # They can be initialized even without `reset_parameters` method,
                 # but we need to warn user about this case.
-                # However, if users provide the `param_init_fn`, we assume they
+                # However, if users provide `param_init_fn`, we assume
                 # those parameters can be handled within that function.
                 for param_name, param in sch.mod.named_parameters(recurse=False):
                     logger.info(

--- a/slapo/build.py
+++ b/slapo/build.py
@@ -107,10 +107,10 @@ def consolidate_model(
             # count number of arguments in the given function to determine whether
             # we should pass in the path of the module or not
             args = inspect.signature(param_init_fn).parameters
-            num_params = (
+            num_args = (
                 len(args) - 1 if args.get("self", None) is not None else len(args)
             )
-            if num_params == 1:
+            if num_args == 1:
                 param_init_fn(sch.mod)
             else:
                 param_init_fn(sch.mod, sch.path)
@@ -122,8 +122,8 @@ def consolidate_model(
             sch.mod.reset_parameters()
         else:
             raise RuntimeError(
-                f"Module {sch.name} should have `reset_parameters` or "
-                "`_init_weights` method or param_init_fn={param_init_fn} needs "
+                f"Module {sch.name} ({type(sch.mod)}) should have `reset_parameters` or "
+                "`_init_weights` method or `param_init_fn` argument needs "
                 "to be provided in order to support delay initialization"
             )
 
@@ -155,7 +155,7 @@ def consolidate_model(
                 param.orig_shape if hasattr(param, "orig_shape") else param.shape
             )
             new_param = nn.Parameter(
-                torch.empty(orig_shape, dtype=param.dtype, device=local_rank)
+                torch.zeros(orig_shape, dtype=param.dtype, device=local_rank)
             )
             sch.mod.register_parameter(
                 param_name,
@@ -166,7 +166,19 @@ def consolidate_model(
         # Use original shape to initialize parameters.
         if global_rank == curr_stage_devices[0] and num_params > 0:
             # only the first device in the PP group needs to initialize the weights
-            _init_module(sch)
+            if len(sch.child) == 0 or callable(param_init_fn):  # leaf module
+                _init_module(sch)
+            else:
+                # Some parameters are directly written in the module, e.g.,
+                # https://github.com/huggingface/transformers/blob/main/src/transformers/models/bert/modeling_bert.py#L693
+                # They can be initialized even without `reset_parameters` method,
+                # but we need to warn user about this case.
+                # However, if users provide the `param_init_fn`, we assume they
+                # those parameters can be handled within that function.
+                for param_name, param in sch.mod.named_parameters(recurse=False):
+                    logger.info(
+                        f"Param {param_name} in Module {sch.path}.{sch.name} is initialized as all zeros"
+                    )
 
         # Broadcast complete params from rank 0 to make sure all the TP+DP ranks
         # take the same params.

--- a/slapo/verify.py
+++ b/slapo/verify.py
@@ -20,7 +20,7 @@ logger = get_logger()
 
 class Verify(ContextDecorator):
     def __init__(
-        self, sch, example_inputs, device="cuda", eval_mode=False, enable=True
+        self, sch, example_inputs, device="cuda", eval_mode=True, enable=True
     ):
         if not isinstance(example_inputs, list):
             example_inputs = [example_inputs]

--- a/slapo/verify.py
+++ b/slapo/verify.py
@@ -19,9 +19,7 @@ logger = get_logger()
 
 
 class Verify(ContextDecorator):
-    def __init__(
-        self, sch, example_inputs, device="cuda", eval_mode=True, enable=True
-    ):
+    def __init__(self, sch, example_inputs, device="cuda", eval_mode=True, enable=True):
         if not isinstance(example_inputs, list):
             example_inputs = [example_inputs]
         self.example_inputs = example_inputs

--- a/slapo/verify.py
+++ b/slapo/verify.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 
 from .schedule import create_schedule
 from .build import build
+from .random import set_random_seed
 from .logger import get_logger
 from .primitives.base import Primitive
 
@@ -95,7 +96,10 @@ class Verify(ContextDecorator):
             for inp in self.example_inputs:
                 dist.broadcast(inp, src=0, group=self.sch.group)
         # 5. Run the original model and the new model
+        #    make sure the random seeds are the same, which may affect the output of dropout
+        set_random_seed(2023)
         original_output = original_mod(*self.example_inputs)
+        set_random_seed(2023)
         new_output = new_mod(*self.example_inputs)
         # 6. Compare the outputs
         torch.testing.assert_close(original_output, new_output)

--- a/slapo/verify.py
+++ b/slapo/verify.py
@@ -19,7 +19,7 @@ logger = get_logger()
 
 
 class Verify(ContextDecorator):
-    def __init__(self, sch, example_inputs, device="cuda"):
+    def __init__(self, sch, example_inputs, device="cuda", enable=True):
         if not isinstance(example_inputs, list):
             example_inputs = [example_inputs]
         self.example_inputs = example_inputs
@@ -27,6 +27,7 @@ class Verify(ContextDecorator):
         self.sch = sch
         self.original_sch = create_schedule(copy.deepcopy(self.sch.mod))
         self.device = device
+        self.enable = enable
 
     def __enter__(self):
         self.original_trace = sys.gettrace()
@@ -55,6 +56,8 @@ class Verify(ContextDecorator):
         """Verify the correctness of the schedule.
         TODO: Support backward verification
         """
+        if not self.enable:
+            return
         # 1. Build the original model with random weights
         named_params = self.original_sch.mod.named_parameters()
         is_initialized = named_params.__next__()[1].device != torch.device("meta")


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR follows #87 to enhance the verification support in order to help programmers find bugs in distributed programs in advance. There are several changes:
1. Enhance the consolidation logic for HF models, so that users need not necessarily provide the `_init_weight` function but can still use PyTorch's method to initialize the model.
2. Add `eval_mode` in the argument of the verifier so users can determine whether they want to include `dropout` layers in the verification process.
3. Change the verification logic. First generate the results of the original model and immediately free it to reduce memory usage.
4. Add a test case to verify the TP sharding of the HF BERT model.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac @zarzen 