### PR TITLE
[Tracer] Add TorchDynamo support

### DIFF
--- a/slapo/tracer.py
+++ b/slapo/tracer.py
@@ -425,7 +425,6 @@ def trace(model: nn.Module, **kwargs: dict[str, Any]):
                 "concrete_args" in kwargs
             ), "Please provide concrete_args for HF tracer"
             concrete_args = kwargs.pop("concrete_args")
-            assert "config" in kwargs, "Please provide config for HF tracer"
 
             class TracerWrapper(HFTracer):
                 def __init__(self, **config: dict[str, Any]) -> None:

--- a/slapo/tracer.py
+++ b/slapo/tracer.py
@@ -425,6 +425,7 @@ def trace(model: nn.Module, **kwargs: dict[str, Any]):
                 "concrete_args" in kwargs
             ), "Please provide concrete_args for HF tracer"
             concrete_args = kwargs.pop("concrete_args")
+            assert "config" in kwargs, "Please provide config for HF tracer"
 
             class TracerWrapper(HFTracer):
                 def __init__(self, **config: dict[str, Any]) -> None:

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -9,6 +9,7 @@ import torch
 from torch import fx
 
 import slapo
+from slapo.pattern import call_module
 
 
 def generate_concrete_args(model, input_names):
@@ -193,6 +194,48 @@ def test_hf_tracer_gpt_attn():
         config=config,
     )
     assert isinstance(subsch.mod, fx.GraphModule)
+
+
+def test_dynamo():
+    from transformers import AutoConfig, BertLMHeadModel
+
+    config = AutoConfig.from_pretrained("bert-large-uncased")
+    with slapo.init_empty_weights():
+        model = BertLMHeadModel(config)
+    sch = slapo.create_schedule(model)
+    subsch = sch[f"bert.encoder.layer.{0}.attention.self"]
+
+    bs, seq_length = 8, 512
+    concrete_args = {"hidden_states": torch.randn(bs, seq_length, config.hidden_size)}
+    sig = inspect.signature(subsch.mod.forward)
+    concrete_args.update(
+        {
+            p.name: p.default
+            for p in sig.parameters.values()
+            if p.name not in concrete_args
+        }
+    )
+    subsch.trace(tracer="dynamo", concrete_args=concrete_args)
+    assert isinstance(subsch.mod, fx.GraphModule)
+
+    def pattern(x):
+        x = call_module(r"self_(query|key|value)", x)
+        x = x.view(
+            (
+                bs,
+                seq_length,
+                config.num_attention_heads,
+                config.hidden_size // config.num_attention_heads,
+            )
+        )
+        return x.permute(0, 2, 1, 3)
+
+    qkv_subgraphs = subsch.find(pattern)
+    assert len(qkv_subgraphs) == 3
+    mod, _ = slapo.build(sch, init_weights=model._init_weights)
+    mod = mod.cuda()
+    inp = torch.ones(bs, seq_length, dtype=torch.long, device="cuda")
+    mod(inp)
 
 
 if __name__ == "__main__":

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -220,14 +220,7 @@ def test_dynamo():
 
     def pattern(x):
         x = call_module(r"self_(query|key|value)", x)
-        x = x.view(
-            (
-                bs,
-                seq_length,
-                config.num_attention_heads,
-                config.hidden_size // config.num_attention_heads,
-            )
-        )
+        x = x.view((8, 512, 16, 64))
         return x.permute(0, 2, 1, 3)
 
     qkv_subgraphs = subsch.find(pattern)


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds TorchDynamo as the backend tracer, providing more use cases when integrating with PyTorch 2.0.
Also, the legacy HF tracer is fixed to support tracing GPT attention modules.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac @zarzen @whbldhwj 