### PR TITLE
[Primitive] .find() & .replace() API enhancement

### DIFF
--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -102,7 +102,7 @@ def vertical_fusion(
     ):
         is_module = False
     ops = subgraphs[0]
-    path, first_node = ops[0]
+    path, _ = ops[0]
     ops = [op[1] for op in ops]
     if path:
         assert hasattr(target_mod, path), f"{path} is not an attribute of {target_mod}"
@@ -152,7 +152,6 @@ def horizontal_fusion(
     if concrete_args is not None:
         raise ValueError("concrete_args is not supported for horizontal fusion")
     path, node = subgraphs[0][0]
-    target_mod = target_mod
     if path:
         assert hasattr(target_mod, path), f"{path} is not an attribute of {target_mod}"
         target_mod = getattr(target_mod, path)

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -118,7 +118,8 @@ def vertical_fusion(
         except ValueError:
             sig = None
     subgraph_args, new_kwargs = get_required_args(sig, ops, concrete_args)
-    with target_mod.graph.inserting_before(first_node):
+    last_node = ops[-1]
+    with target_mod.graph.inserting_after(last_node):
         if is_module:
             new_node = target_mod.graph.call_module(
                 name, tuple(subgraph_args), new_kwargs
@@ -127,7 +128,6 @@ def vertical_fusion(
             new_node = target_mod.graph.call_function(
                 new_mod_or_func, tuple(subgraph_args), new_kwargs
             )
-    last_node = ops[-1]
     last_node.replace_all_uses_with(new_node)
     for node in reversed(ops):
         target_mod.graph.erase_node(node)
@@ -163,7 +163,8 @@ def horizontal_fusion(
     # TODO: Need to handle the case where the replaced module
     # has different numbers of arguments with the original module.
     # Also need more tests.
-    with target_mod.graph.inserting_before(node):
+    _, last_node = subgraphs[-1][-1]
+    with target_mod.graph.inserting_after(last_node):
         if is_module:
             new_node = target_mod.graph.call_module(name, node.args, node.kwargs)
         else:

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -45,46 +45,6 @@ def _get_unique_module_name(gm_or_modules, name):
     return new_name
 
 
-def _replace_function(sch, func, target_op):
-    """Replace a function, in terms of a call_function node in fx graph.
-    Do NOT directly call this function, use `.replace()` instead
-
-    Parameters
-    ----------
-    sch : Schedule
-        The schedule with the function to be replaced.
-    func : Callable
-        The new function to replace the current function.
-    target_op : List[Tuple[str, torch.fx.Node]]
-        The call_function node to be replaced.
-        The string in the tuple is the name of the parent module that
-        the node belongs to.
-    """
-    if isinstance(target_op, list):
-        try:
-            sig = inspect.signature(func)
-        except ValueError:
-            sig = None
-        target_op = target_op[0]
-        _, first_node = target_op[0]
-        target_op = [op[1] for op in target_op]
-        subgraph_args, new_kwargs = get_required_args(sig, target_op)
-        with sch.mod.graph.inserting_before(first_node):
-            new_node = sch.mod.graph.call_function(
-                func, tuple(subgraph_args), new_kwargs
-            )
-        last_node = target_op[-1]
-        last_node.replace_all_uses_with(new_node)
-        for node in reversed(target_op):
-            sch.mod.graph.erase_node(node)
-    else:
-        _, node = target_op
-        with sch.mod.graph.inserting_after(node):
-            new_node = sch.mod.graph.call_function(func, node.args, node.kwargs)
-        node.replace_all_uses_with(new_node)
-        sch.mod.graph.erase_node(node)
-
-
 def get_required_args(sig, ops, concrete_args=None):
     first_node = ops[0]
     if sig is None:
@@ -126,6 +86,128 @@ def get_required_args(sig, ops, concrete_args=None):
             "specify the arguments."
         )
     return subgraph_args, new_kwargs
+
+
+def vertical_fusion(
+    target_mod, subgraphs, new_mod_or_func, name=None, concrete_args=None
+):
+    """Vertical fusion.
+    e.g., s0->v0->s1->v1->s2->v2
+    [[s0, v0, s1, v1, s2, v2]]
+    """
+    is_module = True
+    if (
+        isinstance(new_mod_or_func, FunctionType)
+        or type(new_mod_or_func).__name__ == "builtin_function_or_method"
+    ):
+        is_module = False
+    ops = subgraphs[0]
+    path, first_node = ops[0]
+    ops = [op[1] for op in ops]
+    if path:
+        assert hasattr(target_mod, path), f"{path} is not an attribute of {target_mod}"
+        target_mod = getattr(target_mod, path)
+
+    if is_module:
+        assert name is not None, "Please specify the name of the new module"
+        target_mod.add_module(name, new_mod_or_func)
+        sig = inspect.signature(new_mod_or_func.forward)
+    else:
+        try:
+            sig = inspect.signature(new_mod_or_func)
+        except ValueError:
+            sig = None
+    subgraph_args, new_kwargs = get_required_args(sig, ops, concrete_args)
+    with target_mod.graph.inserting_before(first_node):
+        if is_module:
+            new_node = target_mod.graph.call_module(
+                name, tuple(subgraph_args), new_kwargs
+            )
+        else:
+            new_node = target_mod.graph.call_function(
+                new_mod_or_func, tuple(subgraph_args), new_kwargs
+            )
+    last_node = ops[-1]
+    last_node.replace_all_uses_with(new_node)
+    for node in reversed(ops):
+        target_mod.graph.erase_node(node)
+
+
+def horizontal_fusion(
+    target_mod, subgraphs, new_mod_or_func, name=None, concrete_args=None
+):
+    """Horizontal fusion.
+        x
+      / | \
+    s0 s1 s2
+    v0 v1 v2
+    [[s0, v0], [s1, v1], [s2, v2]]
+    """
+    is_module = True
+    if (
+        isinstance(new_mod_or_func, FunctionType)
+        or type(new_mod_or_func).__name__ == "builtin_function_or_method"
+    ):
+        is_module = False
+    if concrete_args is not None:
+        raise ValueError("concrete_args is not supported for horizontal fusion")
+    path, node = subgraphs[0][0]
+    target_mod = target_mod
+    if path:
+        assert hasattr(target_mod, path), f"{path} is not an attribute of {target_mod}"
+        target_mod = getattr(target_mod, path)
+
+    if is_module:
+        assert name is not None, "Please specify the name of the new module"
+        target_mod.add_module(name, new_mod_or_func)
+    # TODO: Need to handle the case where the replaced module
+    # has different numbers of arguments with the original module.
+    # Also need more tests.
+    with target_mod.graph.inserting_before(node):
+        if is_module:
+            new_node = target_mod.graph.call_module(name, node.args, node.kwargs)
+        else:
+            new_node = target_mod.graph.call_function(
+                new_mod_or_func, node.args, node.kwargs
+            )
+    with target_mod.graph.inserting_after(new_node):
+        for i, sublst in enumerate(subgraphs):
+            getitem = target_mod.graph.call_function(operator.getitem, (new_node, i))
+            sublst = [sublst] if not isinstance(sublst, list) else sublst
+            for _, node in reversed(sublst):
+                if node.users not in sublst:
+                    node.replace_all_uses_with(getitem)
+                target_mod.graph.erase_node(node)
+
+
+def _replace_function(sch, func, target_op):
+    """Replace a function, in terms of a call_function node in fx graph.
+    Do NOT directly call this function, use `.replace()` instead
+
+    Parameters
+    ----------
+    sch : Schedule
+        The schedule with the function to be replaced.
+    func : Callable
+        The new function to replace the current function.
+    target_op : List[Tuple[str, torch.fx.Node]]
+        The call_function node to be replaced.
+        The string in the tuple is the name of the parent module that
+        the node belongs to.
+    """
+    if isinstance(target_op, list):
+        sch.trace()
+        assert len(target_op) > 0, "Should have at least one operator to replace"
+        if len(target_op) > 1:
+            horizontal_fusion(sch.mod, target_op, func)
+        else:
+            vertical_fusion(sch.mod, target_op, func)
+    else:
+        _, node = target_op
+        with sch.mod.graph.inserting_after(node):
+            new_node = sch.mod.graph.call_function(func, node.args, node.kwargs)
+        node.replace_all_uses_with(new_node)
+        sch.mod.graph.erase_node(node)
 
 
 def _replace_module(self_sch, new_mod, subgraphs=None, name=None, concrete_args=None):
@@ -183,62 +265,14 @@ def _replace_module(self_sch, new_mod, subgraphs=None, name=None, concrete_args=
         self_sch.trace()
         assert len(subgraphs) > 0, "Should have at least one operator to replace"
         if len(subgraphs) > 1:
-            # horizontal fusion, e.g.,
-            #     x
-            #   / | \
-            #  s0 s1 s2
-            #  v0 v1 v2
-            #  [[s0, v0], [s1, v1], [s2, v2]]
-            path, node = subgraphs[0][0]
-            target_mod = self_sch.mod
-            if path:
-                assert hasattr(
-                    self_sch.mod, path
-                ), f"{path} is not an attribute of {self_sch.mod}"
-                target_mod = getattr(self_sch.mod, path)
-
-            target_mod.add_module(name, new_mod)
-            # TODO: Need to handle the case where the replaced module
-            # has different numbers of arguments with the original module.
-            # Also need more tests.
-            with target_mod.graph.inserting_before(node):
-                new_node = target_mod.graph.call_module(name, node.args, node.kwargs)
-            with target_mod.graph.inserting_after(new_node):
-                for i, sublst in enumerate(subgraphs):
-                    getitem = target_mod.graph.call_function(
-                        operator.getitem, (new_node, i)
-                    )
-                    sublst = [sublst] if not isinstance(sublst, list) else sublst
-                    for _, node in reversed(sublst):
-                        if node.users not in sublst:
-                            node.replace_all_uses_with(getitem)
-                        target_mod.graph.erase_node(node)
+            horizontal_fusion(
+                self_sch.mod, subgraphs, new_mod, name=name, concrete_args=concrete_args
+            )
             transfer_hooks_for_fusion(self_sch, subgraphs, new_mod)
         else:
-            # vertical fusion, e.g.,
-            # s0->v0
-            # [[s0, v0]]
-            ops = subgraphs[0]
-            path, first_node = ops[0]
-            ops = [op[1] for op in ops]
-            target_mod = self_sch.mod
-            if path:
-                assert hasattr(
-                    self_sch.mod, path
-                ), f"{path} is not an attribute of {self_sch.mod}"
-                target_mod = getattr(self_sch.mod, path)
-
-            target_mod.add_module(name, new_mod)
-            sig = inspect.signature(new_mod.forward)
-            subgraph_args, new_kwargs = get_required_args(sig, ops, concrete_args)
-            with target_mod.graph.inserting_before(first_node):
-                new_node = target_mod.graph.call_module(
-                    name, tuple(subgraph_args), new_kwargs
-                )
-            last_node = ops[-1]
-            last_node.replace_all_uses_with(new_node)
-            for node in reversed(ops):
-                target_mod.graph.erase_node(node)
+            vertical_fusion(
+                self_sch.mod, subgraphs, new_mod, name=name, concrete_args=concrete_args
+            )
             transfer_hooks_for_fusion(self_sch, subgraphs, new_mod)
         # Update schedules
         self_sch.child[name] = new_sch

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -363,10 +363,11 @@ class Schedule:
             else:
                 # Workaround for fx wrap functions:
                 # https://github.com/pytorch/pytorch/issues/53534
-                exec(
-                    "import torch.fx; torch.fx.wrap('call_module')",
-                    pattern_fn.__globals__,
-                )
+                if "call_module" in pattern_fn.__globals__:
+                    exec(
+                        "import torch.fx; torch.fx.wrap('call_module')",
+                        pattern_fn.__globals__,
+                    )
                 pattern_mod = fx.symbolic_trace(pattern_fn)
         assert isinstance(pattern_mod, fx.GraphModule)
 

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=exec-used
 from __future__ import annotations
 
 import re

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -354,9 +354,8 @@ class Schedule:
 
         if pattern_fn is not None:
             if isinstance(pattern_fn, Pattern):
-                pattern_wrapper = pattern_fn
                 pattern_mod = trace_module(
-                    pattern_wrapper,
+                    pattern_fn,
                     recursive=True,
                     flatten=True,
                     leaf_modules=["ModulePattern"],
@@ -368,8 +367,7 @@ class Schedule:
                     "import torch.fx; torch.fx.wrap('call_module')",
                     pattern_fn.__globals__,
                 )
-                pattern_wrapper = pattern_fn
-                pattern_mod = fx.symbolic_trace(pattern_wrapper)
+                pattern_mod = fx.symbolic_trace(pattern_fn)
         assert isinstance(pattern_mod, fx.GraphModule)
 
         first_op = None

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -21,7 +21,7 @@ from .primitives import PRIMITIVES
 from .pipeline import analyze_tie_weights
 
 from .tracer import trace as trace_module
-from .utils.common import is_lambda_function, is_module_list
+from .utils.common import is_module_list
 from .utils.mapping import MAPPING_FROM_FUNCTIONAL_TO_MODULE
 from .pattern import Pattern, ModulePattern
 

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -271,9 +271,7 @@ class Schedule:
         """
 
         named_modules = dict(self.mod.named_modules())
-        assert isinstance(
-            pattern_fn, (FunctionType, Pattern)
-        ) and not is_lambda_function(pattern_fn)
+        assert isinstance(pattern_fn, (FunctionType, Pattern))
 
         def find_match_subgraph(curr, target, subgraph):
             if target.op == "output":

--- a/slapo/schedule.py
+++ b/slapo/schedule.py
@@ -361,7 +361,7 @@ class Schedule:
             else:
                 # Workaround for fx wrap functions:
                 # https://github.com/pytorch/pytorch/issues/53534
-                exec("torch.fx.wrap('call_module')", pattern_fn.__globals__)
+                exec("import torch.fx; torch.fx.wrap('call_module')", pattern_fn.__globals__)
                 pattern_wrapper = pattern_fn
                 pattern_mod = fx.symbolic_trace(pattern_wrapper)
         assert isinstance(pattern_mod, fx.GraphModule)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -3,9 +3,11 @@
 """Test replace primitives."""
 # pylint: disable=comparison-with-callable, unused-argument
 
+import math
 import operator
 import pytest
 
+import torch
 from torch import nn
 import torch.nn.functional as F
 
@@ -378,6 +380,112 @@ def test_transfer_hook():
     assert len(all_hooks["fwd_pre"]) == 1
     assert len(all_hooks["fwd_post"]) == 1
     assert len(all_hooks["bwd_post"]) == 1
+
+
+def get_traced_bert():
+    from transformers import BertLMHeadModel, AutoConfig
+    import inspect
+    from torch import fx
+
+    config = AutoConfig.from_pretrained("bert-large-uncased")
+    with slapo.init_empty_weights():
+        model = BertLMHeadModel(config)
+
+    sch = slapo.create_schedule(model)
+    input_names = ["hidden_states"]
+    subsch = sch["bert.encoder.layer.0.attention.self"]
+    sig = inspect.signature(subsch.mod.forward)
+    concrete_args = {
+        p.name: p.default for p in sig.parameters.values() if p.name not in input_names
+    }
+    subsch.trace(
+        recursive=False, flatten=True, tracer="pytorch", concrete_args=concrete_args
+    )
+    assert isinstance(subsch.mod, fx.GraphModule)
+    return subsch, config
+
+
+def test_qkv():
+    subsch, _ = get_traced_bert()
+
+    def pattern(x):
+        x = call_module(r"(query|key|value)", x)
+        new_shape = x.size()[:-1] + (16, -1)
+        x = x.view(new_shape)
+        return x.permute(0, 2, 1, 3)
+
+    qkv_subgraphs = subsch.find(pattern)
+    assert len(qkv_subgraphs) == 3
+    for subgraph in qkv_subgraphs:
+        assert len(subgraph) == 6
+    # make sure matching different nodes
+    assert qkv_subgraphs[0][0][1].target == "query"
+    assert qkv_subgraphs[0][1][1].name == "size"
+    assert qkv_subgraphs[1][0][1].target == "key"
+    assert qkv_subgraphs[1][1][1].name == "size_1"
+    assert qkv_subgraphs[2][0][1].target == "value"
+    assert qkv_subgraphs[2][1][1].name == "size_2"
+
+    def qkv(x):
+        return (x, x, x)
+
+    subsch.replace(qkv, qkv_subgraphs)
+    cnt = 0
+    for node in subsch.mod.graph.nodes:
+        if node.target == operator.getitem and node.args[0].target == qkv:
+            cnt += 1
+    assert cnt == 3
+
+    subsch_1, _ = get_traced_bert()
+    qkv_subgraphs_1 = subsch_1.find(pattern)
+
+    class Identity(nn.Module):
+        def forward(self, x):
+            return (x, x, x)
+
+    subsch_1.replace(Identity(), qkv_subgraphs_1)
+    cnt = 0
+    for node in subsch_1.mod.graph.nodes:
+        if node.target == operator.getitem and node.args[0].target == "Identity_0":
+            cnt += 1
+    assert cnt == 3
+
+
+def test_efficient_attn():
+    subsch, config = get_traced_bert()
+
+    # https://pytorch.org/docs/master/generated/torch.nn.functional.scaled_dot_product_attention.html
+    def scaled_dot_product(query_layer, key_layer, value_layer):
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(
+            config.hidden_size // config.num_attention_heads
+        )
+        attention_probs = F.softmax(attention_scores, dim=-1)
+        attention_probs = F.dropout(attention_probs)
+        context_layer = torch.matmul(attention_probs, value_layer)
+        return context_layer
+
+    subgraphs = subsch.find(scaled_dot_product)
+    assert len(subgraphs[0]) == 6
+    inp = torch.randn(1, 512, 1024)
+    # Test replacing with a function
+    # query, key, value argument orders are different
+    # should be able to replace, but the results are incorrect
+    with pytest.raises(AssertionError):
+        with slapo.Verify(subsch, [inp]):
+            subsch.replace(F.scaled_dot_product_attention, subgraphs)
+
+    subsch_1, _ = get_traced_bert()
+    subgraphs_1 = subsch_1.find(scaled_dot_product)
+    assert len(subgraphs_1[0]) == 6
+
+    class EfficientAttention(torch.nn.Module):
+        def forward(self, key_layer, query_layer, value_layer):
+            return F.scaled_dot_product_attention(query_layer, key_layer, value_layer)
+
+    # Test replacing with a module
+    with slapo.Verify(subsch_1, [inp]):
+        subsch_1.replace(EfficientAttention(), subgraphs_1)
 
 
 if __name__ == "__main__":

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -368,6 +368,22 @@ def test_insertion_point():
         assert node.name == names[i]
 
 
+def test_lambda():
+    class Model(nn.Module):
+        def forward(self, a, b):
+            x = a + b
+            y = a - x
+            return y
+
+    model = Model()
+    sch = slapo.create_schedule(model)
+    subgraph = sch.find(lambda a, b: a + b)
+    sch.replace(lambda a, b: a * b, subgraph)
+    subgraph = sch.find(lambda a, b: a - b)
+    sch.replace(lambda a, b: b // a, subgraph)
+    assert sch.mod(4, 10) == 10
+
+
 def test_transfer_hook():
     """Test whether the hooks are transferred to the new replaced module."""
 

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -3,7 +3,6 @@
 """Test operator fusion."""
 
 # pylint: disable=comparison-with-callable
-import math
 import operator
 import pytest
 import torch
@@ -282,47 +281,6 @@ def test_pattern_call_module_class():
         assert isinstance(sch.get_module(subgraph[i][1][1].target), nn.ReLU)
 
 
-def get_traced_bert():
-    from transformers import BertLMHeadModel, AutoConfig
-    import inspect
-    from torch import fx
-
-    config = AutoConfig.from_pretrained("bert-large-uncased")
-    with slapo.init_empty_weights():
-        model = BertLMHeadModel(config)
-
-    sch = slapo.create_schedule(model)
-    input_names = ["hidden_states"]
-    subsch = sch["bert.encoder.layer.0.attention.self"]
-    sig = inspect.signature(subsch.mod.forward)
-    concrete_args = {
-        p.name: p.default for p in sig.parameters.values() if p.name not in input_names
-    }
-    subsch.trace(
-        recursive=False, flatten=True, tracer="pytorch", concrete_args=concrete_args
-    )
-    assert isinstance(subsch.mod, fx.GraphModule)
-    return subsch, config
-
-
-def test_qkv():
-    subsch, _ = get_traced_bert()
-
-    def pattern(x):
-        x = call_module(r"(query|key|value)", x)
-        new_shape = x.size()[:-1] + (16, -1)
-        x = x.view(new_shape)
-        return x.permute(0, 2, 1, 3)
-
-    qkv_subgraphs = subsch.find(pattern)
-    assert len(qkv_subgraphs) == 3
-    for subgraph in qkv_subgraphs:
-        assert len(subgraph) == 6
-    assert qkv_subgraphs[0][0][1].target == "query"
-    assert qkv_subgraphs[1][0][1].target == "key"
-    assert qkv_subgraphs[2][0][1].target == "value"
-
-
 def test_diamond():
     class Diamond(nn.Module):
         def __init__(self):
@@ -362,45 +320,6 @@ def test_diamond():
     assert subgraph[1][1].target == operator.mul
     assert subgraph[2][1].target == operator.mul
     assert subgraph[3][1].target == operator.add
-
-
-def test_efficient_attn():
-    subsch, config = get_traced_bert()
-
-    # https://pytorch.org/docs/master/generated/torch.nn.functional.scaled_dot_product_attention.html
-    def scaled_dot_product(query_layer, key_layer, value_layer):
-        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
-        attention_scores = attention_scores / math.sqrt(
-            config.hidden_size // config.num_attention_heads
-        )
-        attention_probs = F.softmax(attention_scores, dim=-1)
-        attention_probs = F.dropout(attention_probs)
-        context_layer = torch.matmul(attention_probs, value_layer)
-        return context_layer
-
-    subgraphs = subsch.find(scaled_dot_product)
-    assert len(subgraphs[0]) == 6
-    inp = torch.randn(1, 512, 1024)
-    # Test replacing with a function
-    # query, key, value argument orders are different
-    # should be able to replace, but the results are incorrect
-    with pytest.raises(AssertionError):
-        with slapo.Verify(subsch, [inp]):
-            subsch.replace(F.scaled_dot_product_attention, subgraphs)
-
-    subsch_1, _ = get_traced_bert()
-    subgraphs_1 = subsch_1.find(scaled_dot_product)
-    assert len(subgraphs_1[0]) == 6
-
-    class EfficientAttention(torch.nn.Module):
-        def forward(self, key_layer, query_layer, value_layer):
-            return torch.nn.functional.scaled_dot_product_attention(
-                query_layer, key_layer, value_layer
-            )
-
-    # Test replacing with a module
-    with slapo.Verify(subsch_1, [inp]):
-        subsch_1.replace(EfficientAttention(), subgraphs_1)
 
 
 if __name__ == "__main__":

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -309,7 +309,7 @@ def test_qkv():
     subsch, _ = get_traced_bert()
 
     def pattern(x):
-        x = call_module(r"self\.(query|key|value)", x)
+        x = call_module(r"(query|key|value)", x)
         new_shape = x.size()[:-1] + (16, -1)
         x = x.view(new_shape)
         return x.permute(0, 2, 1, 3)
@@ -318,9 +318,9 @@ def test_qkv():
     assert len(qkv_subgraphs) == 3
     for subgraph in qkv_subgraphs:
         assert len(subgraph) == 6
-    assert qkv_subgraphs[0][0][1].target == "self.query"
-    assert qkv_subgraphs[1][0][1].target == "self.key"
-    assert qkv_subgraphs[2][0][1].target == "self.value"
+    assert qkv_subgraphs[0][0][1].target == "query"
+    assert qkv_subgraphs[1][0][1].target == "key"
+    assert qkv_subgraphs[2][0][1].target == "value"
 
 
 def test_diamond():


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR refactors the `.replace()` and `.find()` primitives to let them support more cases:
1. Based on the discussion in the PyTorch [issue](https://github.com/pytorch/pytorch/issues/53534), we can wrap an fx function inside the pattern function context using `exec`. Therefore, we do not need to manually parse the source code and wrap it in a module, allowing users to write more free-form patterns, e.g. directly calling global variables, using third-party library functions. To be more specific, the following pattern is not allowed before this PR. This PR also adds a complete test case to replace the scaled dot product function in the BERT attention module.
```python
def pattern(attn_scores):
    return attn_scores / math.sqrt(  # non-builtin Python function
        config.hidden_size // config.num_attention_heads  # global variables
    )
```
2. Support replacing a horizontal or vertical pattern with another function. Previously this is not allowed, and users need to wrap the function in a module. The following coding style is now supported.
```python
def pattern(a, b):
    return a + b
def new_func(a, b):
    return a * b
subgraph = sch.find(pattern)
sch.replace(new_func, subgraph)

# Also, lambda functions enable more concise code
subgraph = sch.find(lambda a, b: a + b)
sch.replace(lambda a, b: a * b, subgraph)
```
3. Fix the insertion point of replacement. The original implementation adds the `new_func` before `mul` op, which is incorrect. This PR makes sure the insertion point of the new op is after all those ops to be replaced.
```python
def test_insertion_point():
    class Model(nn.Module):
        def forward(self, a, b, c):
            x = a + b
            y = c * 2
            z = x + y
            return z

    model = Model()
    sch = slapo.create_schedule(model)

    def pattern(a1, b1, y1):
        x1 = a1 + b1
        z1 = x1 + y1
        return z1

    subgraph = sch.find(pattern)

    def new_func(a, b, y):
        return a * b * y

    # The new_func should be inserted *after* the mul node.
    sch.replace(new_func, subgraph)
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac @zarzen 