### PR TITLE
[Pipeline] Fix incorrect argument order in the pipeline module

### DIFF
--- a/examples/gpt2/deepspeed_hf.py
+++ b/examples/gpt2/deepspeed_hf.py
@@ -229,6 +229,9 @@ def train(args):
             # insert None in second and fourth position
             ret.insert(1, None)  # past_key_values
             ret.insert(3, None)  # token_type_ids
+        else:
+            # DeepSpeed pipeline does not accept None as input.
+            pass
 
         # group first inputs
         return [ret[:-1], ret[-1]]

--- a/examples/gpt2/deepspeed_hf.py
+++ b/examples/gpt2/deepspeed_hf.py
@@ -213,15 +213,18 @@ def train(args):
             entry["input_ids"],
             entry["attention_mask"],
             # position_ids
-            torch.arange(len(entry["input_ids"])),
+            torch.arange(len(entry["input_ids"]), requires_grad=False),
             entry["labels"],
         ]
         return ret
 
     def collate_fn(batch, enable_pipeline=True):
         input_ids = torch.tensor([x[0] for x in batch], dtype=torch.long)
-        attention_mask = torch.tensor([x[1] for x in batch], dtype=torch.float16)
+        attention_mask = torch.tensor(
+            [x[1] for x in batch], dtype=torch.float16, requires_grad=False
+        )
         position_ids = torch.stack([x[2] for x in batch])
+        position_ids.requires_grad = False
         labels = torch.tensor([x[3] for x in batch], dtype=torch.long)
 
         ret = [input_ids, attention_mask, position_ids, labels]

--- a/slapo/framework_dialect/deepspeed/pipeline.py
+++ b/slapo/framework_dialect/deepspeed/pipeline.py
@@ -298,6 +298,7 @@ class DeepSpeedPipeStageWrapper(nn.Module):
                 idx = liveness.index(arg_name)
             ordered_args.append(unordered_args[idx])
             if i > 0:
+                # https://github.com/microsoft/DeepSpeed/blob/v0.9.2/deepspeed/runtime/pipe/engine.py#L639
                 assert (
                     torch.is_tensor(unordered_args[idx])
                     and unordered_args[idx].requires_grad is False

--- a/slapo/framework_dialect/deepspeed/pipeline.py
+++ b/slapo/framework_dialect/deepspeed/pipeline.py
@@ -366,12 +366,6 @@ def deepspeed_pipe_engine(
 
     if "loss_fn" not in kwargs:
         raise ValueError("Must provide loss_fn for deepspeed pipeline")
-    if "fp16" in kwargs["config"] and kwargs["config"]["fp16"]["enabled"]:
-        param_dtype = torch.float16
-    elif "bf16" in kwargs["config"] and kwargs["config"]["bf16"]["enabled"]:
-        param_dtype = torch.bfloat16
-    else:
-        param_dtype = torch.float
 
     # Tag all sharded parameters with model parallel attribute for grad clipping.
     cnt_shard = 0
@@ -391,7 +385,6 @@ def deepspeed_pipe_engine(
         topology=topology,
         partition_method="uniform",
         loss_fn=kwargs.get("loss_fn", None),
-        param_dtype=param_dtype,
     )
 
     tie_weights = list(sch_metadata.tie_weights.values())

--- a/slapo/framework_dialect/deepspeed/pipeline.py
+++ b/slapo/framework_dialect/deepspeed/pipeline.py
@@ -395,7 +395,6 @@ def deepspeed_pipe_engine(
         cnt_shard,
     )
 
-    # pylint: disable=unexpected-keyword-arg
     model = pipe.PipelineModule(
         stage_modules,
         topology=topology,

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -280,13 +280,15 @@ class ReplacePrimitive(Primitive):
 
             # Add new child.
             for child_name, submod in sch.mod.named_children():
+                path = sch.path
+                next_path = f"{path}.{child_name}" if path else child_name
                 if child_name not in sch.child:
                     for name_idx, layer in submod.named_children():
                         if is_module_list(submod, child_name, sch):
                             sch.child[f"{child_name}.{name_idx}"] = create_schedule(
                                 layer,
                                 f"{child_name}.{name_idx}",
-                                f"{child_name}.{name_idx}",
+                                f"{next_path}.{name_idx}",
                                 sch,
                                 sch.group,
                             )
@@ -294,7 +296,7 @@ class ReplacePrimitive(Primitive):
                             sch.child[child_name] = create_schedule(
                                 submod,
                                 child_name,
-                                f"{sch.path}.{child_name}",
+                                next_path,
                                 sch,
                                 sch.group,
                             )

--- a/slapo/primitives/replace.py
+++ b/slapo/primitives/replace.py
@@ -262,8 +262,8 @@ class ReplacePrimitive(Primitive):
 
             # Remove OOD child.
             named_children = []
-            for child_name, submod in sch.mod.named_children():
-                if is_module_list(submod):
+            for child_name, submod in sch.mod.named_children():  # immediate children
+                if is_module_list(submod, child_name, sch):
                     named_children += [
                         f"{child_name}.{name_idx}"
                         for name_idx, _ in submod.named_children()
@@ -282,7 +282,7 @@ class ReplacePrimitive(Primitive):
             for child_name, submod in sch.mod.named_children():
                 if child_name not in sch.child:
                     for name_idx, layer in submod.named_children():
-                        if is_module_list(submod):
+                        if is_module_list(submod, child_name, sch):
                             sch.child[f"{child_name}.{name_idx}"] = create_schedule(
                                 layer,
                                 f"{child_name}.{name_idx}",

--- a/tests/test_pipeline_partition.py
+++ b/tests/test_pipeline_partition.py
@@ -10,6 +10,7 @@ from torch import nn
 from torch import fx
 
 import slapo
+from slapo.pipeline import generate_pipeline_partition
 
 
 class Pre(nn.Module):
@@ -89,7 +90,6 @@ def test_pipeline_partition():
             assert isinstance(sch["post"].mod, fx.GraphModule)
 
         sch["layers.0"].cut_pipeline_stage()
-        from slapo.pipeline import generate_pipeline_partition
 
         sch = generate_pipeline_partition(sch)
         # The traced pipeline module should include the pre and post modules.
@@ -231,5 +231,4 @@ def test_deepspeed_analyze_tie_ranks():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_pipeline_partition()
+    pytest.main([__file__])

--- a/tests/test_pipeline_partition.py
+++ b/tests/test_pipeline_partition.py
@@ -22,8 +22,7 @@ class Pre(nn.Module):
         # delibarately add control flow to avoid tracing
         if x.size() > 0:
             return self.linear(x)
-        else:
-            return x
+        return x
 
 
 class Post(nn.Module):


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes the incorrect argument order in the pipeline module. See the following description. The previous implementation only fixes the argument order between pipeline stages, but does not handle the input mismatch.

```python
# GPT2LMHeadModel argument order
(input_ids, past_key_values, attention_mask, token_type_ids, position_ids, ...)
# Actual input arguments to the pipeline module
(input_ids, attention_mask, position_ids)
# Arguments of generated fx pipeline module 
(input_ids, position_ids, attention_mask)
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

cc @comaniac @zarzen 