### PR TITLE
[Pipeline] [Bugfix] Make 3D compatible with dmlc/DeepSpeed

### DIFF
--- a/slapo/framework_dialect/deepspeed/engine.py
+++ b/slapo/framework_dialect/deepspeed/engine.py
@@ -37,7 +37,11 @@ def init_ds_engine(model, **kwargs):
         model_parameters=[p for p in model.parameters() if p.requires_grad],
         mpu=mpu,
     )
-    # hack the DS pipeline runtime
+
+    # `is_pipe_partitioned=True` is the default value due to TP
+    # but slapo has internally handled the partitioned inputs and outputs 
+    # having `is_pipe_partitioned=True` leads to incorrect send receive buffer sizes
+    # which causing hanging
     if model.is_pipe_parallel:
         model.is_pipe_partitioned = False
         model.is_grad_partitioned = False

--- a/slapo/framework_dialect/deepspeed/engine.py
+++ b/slapo/framework_dialect/deepspeed/engine.py
@@ -42,7 +42,7 @@ def init_ds_engine(model, **kwargs):
     # but slapo has internally handled the partitioned inputs and outputs
     # having `is_pipe_partitioned=True` leads to incorrect send receive buffer sizes
     # which causing hanging
-    if model.is_pipe_parallel:
+    if hasattr(model, "is_pipe_parallel") and model.is_pipe_parallel:
         model.is_pipe_partitioned = False
         model.is_grad_partitioned = False
 

--- a/slapo/framework_dialect/deepspeed/engine.py
+++ b/slapo/framework_dialect/deepspeed/engine.py
@@ -41,7 +41,7 @@ def init_ds_engine(model, **kwargs):
     # `is_pipe_partitioned=True` is the default value due to TP
     # but slapo has internally handled the partitioned inputs and outputs
     # having `is_pipe_partitioned=True` leads to incorrect send receive buffer sizes
-    # which causing hanging
+    # which causes hanging
     if hasattr(model, "is_pipe_parallel") and model.is_pipe_parallel:
         model.is_pipe_partitioned = False
         model.is_grad_partitioned = False

--- a/slapo/framework_dialect/deepspeed/engine.py
+++ b/slapo/framework_dialect/deepspeed/engine.py
@@ -37,4 +37,9 @@ def init_ds_engine(model, **kwargs):
         model_parameters=[p for p in model.parameters() if p.requires_grad],
         mpu=mpu,
     )
+    # hack the DS pipeline runtime
+    if model.is_pipe_parallel:
+        model.is_pipe_partitioned = False
+        model.is_grad_partitioned = False
+
     return model, optimizer

--- a/slapo/framework_dialect/deepspeed/engine.py
+++ b/slapo/framework_dialect/deepspeed/engine.py
@@ -39,7 +39,7 @@ def init_ds_engine(model, **kwargs):
     )
 
     # `is_pipe_partitioned=True` is the default value due to TP
-    # but slapo has internally handled the partitioned inputs and outputs 
+    # but slapo has internally handled the partitioned inputs and outputs
     # having `is_pipe_partitioned=True` leads to incorrect send receive buffer sizes
     # which causing hanging
     if model.is_pipe_parallel:

--- a/slapo/framework_dialect/deepspeed/pipeline.py
+++ b/slapo/framework_dialect/deepspeed/pipeline.py
@@ -247,7 +247,7 @@ class DeepSpeedPipeStageWrapper(nn.Module):
             for arg in self.stage_id_2_arg_names[-1]:
                 if arg in self.stage_id_2_arg_names[0]:
                     input_arg_names.append(arg)
-            logger.info(
+            logger.debug(
                 "[%s] Argument order: %s (input) -> %s (stage 0)",
                 self.name,
                 input_arg_names,


### PR DESCRIPTION
<!--- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
- Disable the `is_pipe_partition` and `is_grad_partition` in DeepSpeed PipelineEngine. By default these two vars are `True`, which leads to incorrect send receive buffer sizes. Slapo already handles partitioned inputs from stage to stage. 

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [Model], [Tutorial], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

